### PR TITLE
Add a `recursive` global flag.

### DIFF
--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `recursive` global flag. When set, we will walk all sub-directories looking for `pubspec.yaml` files.
+
 ## 0.2.0
 
 * Support git dependencies in packages.

--- a/mono_repo/README.md
+++ b/mono_repo/README.md
@@ -14,7 +14,8 @@ Manage multiple packages in one source repository.
 Usage: mono_repo <command> [arguments]
 
 Global options:
--h, --help    Print this usage information.
+-h, --help              Print this usage information.
+    --[no-]recursive    Whether to recursively walk sub-directorys looking for packages.
 
 Available commands:
   check       Check the state of the repository.

--- a/mono_repo/lib/src/commands/check.dart
+++ b/mono_repo/lib/src/commands/check.dart
@@ -23,11 +23,12 @@ class CheckCommand extends Command<Null> {
   String get description => 'Check the state of the repository.';
 
   @override
-  Future run() => check();
+  Future run() => check(recursive: globalResults[recursiveFlag] as bool);
 }
 
-Future check({String rootDirectory}) async {
-  var reports = await getPackageReports(rootDirectory: rootDirectory);
+Future check({String rootDirectory, bool recursive: false}) async {
+  var reports = await getPackageReports(
+      rootDirectory: rootDirectory, recursive: recursive);
 
   print(styleBold.wrap('    ** REPORT **'));
   print('');
@@ -38,9 +39,10 @@ Future check({String rootDirectory}) async {
 }
 
 Future<Map<String, PackageReport>> getPackageReports(
-    {String rootDirectory}) async {
+    {String rootDirectory, bool recursive: false}) async {
   rootDirectory ??= p.current;
-  var packages = getPackageConfig(rootDirectory: rootDirectory);
+  var packages =
+      getPackageConfig(rootDirectory: rootDirectory, recursive: recursive);
 
   var pubspecs = <String, Pubspec>{};
   packages.forEach((dir, config) {

--- a/mono_repo/lib/src/commands/init.dart
+++ b/mono_repo/lib/src/commands/init.dart
@@ -22,10 +22,10 @@ class InitCommand extends Command<Null> {
 the packages to target in the current repository.''';
 
   @override
-  Future run() => init();
+  Future run() => init(recursive: globalResults[recursiveFlag] as bool);
 }
 
-Future init() async {
+Future init({bool recursive: false}) async {
   var packagesFileName = p.join(p.current, packageConfigFileName);
   // TODO: check to see if we're in the root of a GIT repo. If not, warn.
 
@@ -41,7 +41,7 @@ Future init() async {
         'Found `pubspec.yaml` in the current directory. Not supported.');
   }
 
-  var packages = getPackageConfig();
+  var packages = getPackageConfig(recursive: recursive);
 
   var file = new File(packagesFileName);
   var writer = new StringBuffer();

--- a/mono_repo/lib/src/commands/presubmit.dart
+++ b/mono_repo/lib/src/commands/presubmit.dart
@@ -40,7 +40,8 @@ class PresubmitCommand extends Command<Null> {
     var passed = await presubmit(
         packages: argResults['package'] as List<String>,
         tasks: argResults['task'] as List<String>,
-        sdkToRun: argResults['sdk'] as String);
+        sdkToRun: argResults['sdk'] as String,
+        recursive: globalResults[recursiveFlag] as bool);
 
     // Set a bad exit code if it failed.
     if (!passed) exitCode = 1;
@@ -61,7 +62,7 @@ Future<bool> presubmit(
     {Iterable<String> packages,
     Iterable<String> tasks,
     String sdkToRun,
-    String rootDirectory}) async {
+    String rootDirectory, bool recursive}) async {
   packages ??= <String>[];
   tasks ??= <String>[];
   sdkToRun ??= _currentSdk;
@@ -72,7 +73,7 @@ Future<bool> presubmit(
         'No $travisShPath file found, please run the `travis` command first.');
   }
 
-  var configs = getTravisConfigs(rootDirectory: rootDirectory);
+  var configs = getTravisConfigs(rootDirectory: rootDirectory, recursive: recursive);
   // By default, run on all packages.
   if (packages.isEmpty) packages = configs.keys;
   packages = packages.toList()..sort();

--- a/mono_repo/lib/src/commands/presubmit.dart
+++ b/mono_repo/lib/src/commands/presubmit.dart
@@ -62,7 +62,8 @@ Future<bool> presubmit(
     {Iterable<String> packages,
     Iterable<String> tasks,
     String sdkToRun,
-    String rootDirectory, bool recursive}) async {
+    String rootDirectory,
+    bool recursive}) async {
   packages ??= <String>[];
   tasks ??= <String>[];
   sdkToRun ??= _currentSdk;
@@ -73,7 +74,8 @@ Future<bool> presubmit(
         'No $travisShPath file found, please run the `travis` command first.');
   }
 
-  var configs = getTravisConfigs(rootDirectory: rootDirectory, recursive: recursive);
+  var configs =
+      getTravisConfigs(rootDirectory: rootDirectory, recursive: recursive);
   // By default, run on all packages.
   if (packages.isEmpty) packages = configs.keys;
   packages = packages.toList()..sort();

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -37,12 +37,14 @@ class _PubSubCommand extends Command<Null> {
   String get description => 'Run `pub $name` against all packages.';
 
   @override
-  Future run() => pub(name);
+  Future run() => pub(name, recursive: globalResults[recursiveFlag] as bool);
 }
 
-Future pub(String pubCommand, {String rootDirectory}) async {
+Future pub(String pubCommand,
+    {String rootDirectory, bool recursive: false}) async {
   rootDirectory ??= p.current;
-  var configs = getPackageConfig(rootDirectory: rootDirectory);
+  var configs =
+      getPackageConfig(rootDirectory: rootDirectory, recursive: recursive);
 
   if (configs.isEmpty) {
     return;

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -20,12 +20,15 @@ class TravisCommand extends Command<Null> {
   String get description => 'Configure Travis-CI for child packages.';
 
   @override
-  Future run() => generateTravisConfig();
+  Future run() =>
+      generateTravisConfig(recursive: globalResults[recursiveFlag] as bool);
 }
 
-Future generateTravisConfig({String rootDirectory}) async {
+Future generateTravisConfig(
+    {String rootDirectory, bool recursive: false}) async {
   rootDirectory ??= p.current;
-  var configs = getTravisConfigs(rootDirectory: rootDirectory);
+  var configs =
+      getTravisConfigs(rootDirectory: rootDirectory, recursive: recursive);
 
   for (var pkg in configs.keys) {
     stderr.writeln(styleBold.wrap('package:$pkg'));

--- a/mono_repo/lib/src/runner.dart
+++ b/mono_repo/lib/src/runner.dart
@@ -9,11 +9,12 @@ import 'commands/init.dart';
 import 'commands/presubmit.dart';
 import 'commands/pub.dart';
 import 'commands/travis.dart';
+import 'utils.dart';
 
 class MonoRepoRunner extends CommandRunner<Null> {
   MonoRepoRunner()
-      : super(
-            'mono_repo', 'Manage multiple packages in one source repository.') {
+      : super('mono_repo',
+            'Manzage multiple packages in one source repository.') {
     [
       new CheckCommand(),
       new InitCommand(),
@@ -21,5 +22,9 @@ class MonoRepoRunner extends CommandRunner<Null> {
       new PubCommand(),
       new TravisCommand()
     ].forEach(addCommand);
+    argParser.addFlag(recursiveFlag,
+        help:
+            'Whether to recursively walk sub-directorys looking for packages.',
+        defaultsTo: false);
   }
 }

--- a/mono_repo/lib/src/runner.dart
+++ b/mono_repo/lib/src/runner.dart
@@ -13,8 +13,8 @@ import 'utils.dart';
 
 class MonoRepoRunner extends CommandRunner<Null> {
   MonoRepoRunner()
-      : super('mono_repo',
-            'Manzage multiple packages in one source repository.') {
+      : super(
+            'mono_repo', 'Manage multiple packages in one source repository.') {
     [
       new CheckCommand(),
       new InitCommand(),

--- a/mono_repo/test/multi_repo_test.dart
+++ b/mono_repo/test/multi_repo_test.dart
@@ -29,7 +29,8 @@ final _helpOutput = '''Manage multiple packages in one source repository.
 Usage: mono_repo <command> [arguments]
 
 Global options:
--h, --help    Print this usage information.
+-h, --help              Print this usage information.
+    --[no-]recursive    Whether to recursively walk sub-directorys looking for packages.
 
 Available commands:
   check       Check the state of the repository.


### PR DESCRIPTION
This flag indicates that we should walk all sub-directories looking for `pubspec.yaml` files.