### PR TITLE
Add support for `before_script` in travis config.

### DIFF
--- a/mono_repo/lib/src/travis_config.dart
+++ b/mono_repo/lib/src/travis_config.dart
@@ -145,12 +145,7 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
 
 @JsonSerializable(includeIfNull: false)
 class DartTask extends Object with _$DartTaskSerializerMixin {
-  static final _tasks = const [
-    'dartfmt',
-    'dartanalyzer',
-    'test',
-    'build_and_test',
-  ];
+  static final _tasks = const ['dartfmt', 'dartanalyzer', 'test'];
   static final _prettyTaskList = _tasks.map((t) => '`$t`').join(', ');
 
   @override
@@ -206,13 +201,6 @@ class DartTask extends Object with _$DartTaskSerializerMixin {
 
       case 'test':
         var value = 'pub run test';
-        if (args != null) {
-          value = '$value $args';
-        }
-        return value;
-
-      case 'build_and_test':
-        var value = 'dart tool/build.dart\n pub run test';
         if (args != null) {
           value = '$value $args';
         }

--- a/mono_repo/lib/src/travis_config.g.dart
+++ b/mono_repo/lib/src/travis_config.g.dart
@@ -32,7 +32,8 @@ TravisConfig _$TravisConfigFromJson(Map<String, dynamic> json) =>
             ?.map((e) => e == null
                 ? null
                 : new TravisJob.fromJson(e as Map<String, dynamic>))
-            ?.toList());
+            ?.toList(),
+        json['beforeScript'] as String);
 
 abstract class _$TravisConfigSerializerMixin {
   List<String> get sdks;
@@ -40,12 +41,14 @@ abstract class _$TravisConfigSerializerMixin {
   List<TravisJob> get include;
   List<TravisJob> get exclude;
   List<TravisJob> get allowFailures;
+  String get beforeScript;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'sdks': sdks,
         'tasks': tasks,
         'include': include,
         'exclude': exclude,
-        'allowFailures': allowFailures
+        'allowFailures': allowFailures,
+        'beforeScript': beforeScript
       };
 }
 

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -62,6 +62,8 @@ dart_task:
  - test: --preset travis --total-shards 5 --shard-index 1
  - test
  - dartanalyzer
+ 
+before_script: tool/build.sh
 
 matrix:
   exclude:

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -146,6 +146,11 @@ fi
 pushd $PKG
 pub upgrade
 
+case $PKG in
+*) echo -e "No before_script specified for PKG '${PKG}'."
+  ;;
+esac
+
 case $TASK in
 dartfmt) echo
   echo -e "TASK: dartfmt"
@@ -175,6 +180,15 @@ fi
 
 pushd $PKG
 pub upgrade
+
+case $PKG in
+sub_pkg) echo
+  echo -e "PKG: sub_pkg"
+  tool/build.sh
+  ;;
+*) echo -e "No before_script specified for PKG '${PKG}'."
+  ;;
+esac
 
 case $TASK in
 dartanalyzer) echo

--- a/mono_repo/test/travis_config_test.dart
+++ b/mono_repo/test/travis_config_test.dart
@@ -53,6 +53,14 @@ void main() {
 
       expect(encodeJson(jobs), encodeJson(_testConfig1expectedOutput));
     });
+
+    test('before_script', () {
+      var travisYaml = y.loadYaml(testConfig2) as Map<String, dynamic>;
+
+      var config = new TravisConfig.parse(travisYaml);
+
+      expect(config.beforeScript, 'tool/build.sh');
+    });
   });
 }
 


### PR DESCRIPTION
Add support for `before_script` in travis config. This allows us to specify a custom script to run, per-package, before running any of the dart tasks.

For an example of how this can be used, we are running a build in `angular` before running tests.

Fixes #24 

This also refactors `lib/src/commands/travis.dart` into a bunch of smaller methods, which hopefully makes it easier to follow what that file does.