### PR TITLE
mono_config test: validate formatted output, add tests

### DIFF
--- a/mono_repo/lib/src/utils.dart
+++ b/mono_repo/lib/src/utils.dart
@@ -171,13 +171,8 @@ String prettyPrintCheckedFromJsonException(CheckedFromJsonException err) {
 
   String message;
   if (yamlKey == null) {
-    var innerError = err.innerError;
-    if (innerError is ArgumentError) {
-      message = '${innerError.message}';
-    } else {
-      message = '${err.innerError}';
-    }
-    message = '${yamlMap.span.message(message)}';
+    assert(err.message != null);
+    message = '${yamlMap.span.message(err.message.toString())}';
   } else {
     if (err.message == null) {
       message = 'Unsupported value for `${err.key}`.';


### PR DESCRIPTION
Simplify pretty print logic
reorganize test layout