### PR TITLE
Support custom job descriptions in .mono_repo.yml files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
-      name: "SDK: dev&nbsp;&nbsp;&nbsp;&nbsp;DIR: mono_repo&nbsp;&nbsp;&nbsp;&nbsp;Description: dartfmt && dartanalyzer"
+      name: "SDK: dev - DIR: mono_repo - TASKS: dartfmt && dartanalyzer"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="mono_repo"
       dart: dev
     - stage: build
-      name: "SDK: dev&nbsp;&nbsp;&nbsp;&nbsp;DIR: mono_repo&nbsp;&nbsp;&nbsp;&nbsp;Description: [pub run build_runner build test --delete-conflicting-outputs]"
+      name: "SDK: dev - DIR: mono_repo - TASKS: pub run build_runner build test --delete-conflicting-outputs"
       script: ./tool/travis.sh command_0
       env: PKG="mono_repo"
       dart: dev
     - stage: unit_test
-      name: "SDK: dev&nbsp;&nbsp;&nbsp;&nbsp;DIR: mono_repo&nbsp;&nbsp;&nbsp;&nbsp;Description: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
+      name: "SDK: dev - DIR: mono_repo - TASKS: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
       script: ./tool/travis.sh command_1 command_2
       env: PKG="mono_repo"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
-      name: "Dart: dev   Package: mono_repo   Description: dartfmt && dartanalyzer"
+      name: "<strong>Dart:</strong> dev <strong>Package:</strong> mono_repo <strong>Description</<strong>: dartfmt && dartanalyzer"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="mono_repo"
       dart: dev
     - stage: build
-      name: "Dart: dev   Package: mono_repo   Description: pub run build_runner build test --delete-conflicting-outputs"
+      name: "<strong>Dart:</strong> dev <strong>Package:</strong> mono_repo <strong>Description</<strong>: [pub run build_runner build test --delete-conflicting-outputs]"
       script: ./tool/travis.sh command_0
       env: PKG="mono_repo"
       dart: dev
     - stage: unit_test
-      name: "Dart: dev   Package: mono_repo   Description: pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only"
+      name: "<strong>Dart:</strong> dev <strong>Package:</strong> mono_repo <strong>Description</<strong>: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
       script: ./tool/travis.sh command_1 command_2
       env: PKG="mono_repo"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
+      name: "mono_repo: dartfmt && dartanalyzer"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="mono_repo"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,17 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
-      name: "mono_repo: dartfmt && dartanalyzer"
+      name: "Dart: dev   Package: mono_repo   Description: dartfmt && dartanalyzer"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="mono_repo"
       dart: dev
     - stage: build
+      name: "Dart: dev   Package: mono_repo   Description: pub run build_runner build test --delete-conflicting-outputs"
       script: ./tool/travis.sh command_0
       env: PKG="mono_repo"
       dart: dev
     - stage: unit_test
+      name: "Dart: dev   Package: mono_repo   Description: pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only"
       script: ./tool/travis.sh command_1 command_2
       env: PKG="mono_repo"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
-      name: "<strong>Dart:</strong> dev <strong>Package:</strong> mono_repo <strong>Description</<strong>: dartfmt && dartanalyzer"
+      name: "**Dart:** dev **Package:** mono_repo **Description**: dartfmt && dartanalyzer"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="mono_repo"
       dart: dev
     - stage: build
-      name: "<strong>Dart:</strong> dev <strong>Package:</strong> mono_repo <strong>Description</<strong>: [pub run build_runner build test --delete-conflicting-outputs]"
+      name: "**Dart:** dev **Package:** mono_repo **Description**: [pub run build_runner build test --delete-conflicting-outputs]"
       script: ./tool/travis.sh command_0
       env: PKG="mono_repo"
       dart: dev
     - stage: unit_test
-      name: "<strong>Dart:</strong> dev <strong>Package:</strong> mono_repo <strong>Description</<strong>: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
+      name: "**Dart:** dev **Package:** mono_repo **Description**: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
       script: ./tool/travis.sh command_1 command_2
       env: PKG="mono_repo"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,17 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
-      name: "Dart SDK: dev
-Directory: mono_repo
-Description: dartfmt && dartanalyzer"
+      name: "SDK: dev&nbsp;&nbsp;&nbsp;&nbsp;DIR: mono_repo&nbsp;&nbsp;&nbsp;&nbsp;Description: dartfmt && dartanalyzer"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="mono_repo"
       dart: dev
     - stage: build
-      name: "Dart SDK: dev
-Directory: mono_repo
-Description: [pub run build_runner build test --delete-conflicting-outputs]"
+      name: "SDK: dev&nbsp;&nbsp;&nbsp;&nbsp;DIR: mono_repo&nbsp;&nbsp;&nbsp;&nbsp;Description: [pub run build_runner build test --delete-conflicting-outputs]"
       script: ./tool/travis.sh command_0
       env: PKG="mono_repo"
       dart: dev
     - stage: unit_test
-      name: "Dart SDK: dev
-Directory: mono_repo
-Description: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
+      name: "SDK: dev&nbsp;&nbsp;&nbsp;&nbsp;DIR: mono_repo&nbsp;&nbsp;&nbsp;&nbsp;Description: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
       script: ./tool/travis.sh command_1 command_2
       env: PKG="mono_repo"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,23 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
-      name: "**Dart:** dev **Package:** mono_repo **Description**: dartfmt && dartanalyzer"
+      name: "Dart SDK: dev
+Directory: mono_repo
+Description: dartfmt && dartanalyzer"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="mono_repo"
       dart: dev
     - stage: build
-      name: "**Dart:** dev **Package:** mono_repo **Description**: [pub run build_runner build test --delete-conflicting-outputs]"
+      name: "Dart SDK: dev
+Directory: mono_repo
+Description: [pub run build_runner build test --delete-conflicting-outputs]"
       script: ./tool/travis.sh command_0
       env: PKG="mono_repo"
       dart: dev
     - stage: unit_test
-      name: "**Dart:** dev **Package:** mono_repo **Description**: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
+      name: "Dart SDK: dev
+Directory: mono_repo
+Description: [pub run build_runner test -- -x presubmit-only, pub run build_runner test -- --run-skipped -t presubmit-only]"
       script: ./tool/travis.sh command_1 command_2
       env: PKG="mono_repo"
       dart: dev

--- a/mono_repo/.mono_repo.yml
+++ b/mono_repo/.mono_repo.yml
@@ -4,7 +4,7 @@ dart:
 
 stages:
   - smoke_test:
-    - name: "dartfmt && dartanalyzer"
+    - description: "dartfmt && dartanalyzer"
       group:
         - dartfmt
         - dartanalyzer: --fatal-infos --fatal-warnings .

--- a/mono_repo/.mono_repo.yml
+++ b/mono_repo/.mono_repo.yml
@@ -4,7 +4,8 @@ dart:
 
 stages:
   - smoke_test:
-    - group:
+    - name: "dartfmt && dartanalyzer"
+      group:
         - dartfmt
         - dartanalyzer: --fatal-infos --fatal-warnings .
   - build:

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,6 +1,16 @@
 ## 0.3.3
 
 * Support adding custom cache directories in each project.
+* Add custom names for travis jobs based on the actual tasks being ran, as well
+  as the sdk and subdirectory. The job description portion is configurable with
+  the new `description` key for jobs within a stage, for example:
+
+```yaml
+stages:
+  - unit_test:
+    - description: "chrome"
+      test: -p chrome
+```
 
 ## 0.3.2+1
 
@@ -21,7 +31,7 @@
   normal format. This can be used to group multiple tasks in a single travis
   job. All tasks will be ran, but if any of them fail then the whole job will
   fail.
-  
+
   Example usage combining the analyzer/dartfmt tasks:
 
 ```yaml
@@ -74,7 +84,7 @@ stages:
 
   * Print out the full command that executed as part of a task.
 
-  * Support a `List` value for `before_script`. 
+  * Support a `List` value for `before_script`.
 
 ## 0.2.1
 
@@ -82,7 +92,7 @@ stages:
 
   * Write ANSI escape sequences in `./tool/travis.sh` as pre-escaped ASCII
     literals.
-  
+
   * Added `--[no-]pretty-ansi` flag to allow ANSI sequences to be optionally
     omitted.
 
@@ -97,7 +107,7 @@ stages:
 
 * Support git dependencies in packages.
 
-* Use `mono_repo.yaml` as the configuration file name, instead of 
+* Use `mono_repo.yaml` as the configuration file name, instead of
   `packages.yaml`.
 
 ## 0.1.0

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -305,9 +305,12 @@ String _listJobs(Iterable<TravisJob> jobs, Map<String, String> commandsToKeys) {
   for (var job in jobs) {
     var commands =
         job.tasks.map((task) => commandsToKeys[task.command]).join(' ');
+    var jobName = 'SDK: ${job.sdk}&nbsp;&nbsp;&nbsp;&nbsp;'
+        'DIR: ${job.package}&nbsp;&nbsp;&nbsp;&nbsp;'
+        'Description: ${job.name}';
     buffer.writeln('''
     - stage: ${job.stageName}
-      name: "Dart SDK: ${job.sdk}\nDirectory: ${job.package}\nDescription: ${job.name}"
+      name: "$jobName"
       script: ./tool/travis.sh $commands
       env: PKG="${job.package}"
       dart: ${job.sdk}''');

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -305,9 +305,9 @@ String _listJobs(Iterable<TravisJob> jobs, Map<String, String> commandsToKeys) {
   for (var job in jobs) {
     var commands =
         job.tasks.map((task) => commandsToKeys[task.command]).join(' ');
-    var jobName = 'SDK: ${job.sdk}&nbsp;&nbsp;&nbsp;&nbsp;'
-        'DIR: ${job.package}&nbsp;&nbsp;&nbsp;&nbsp;'
-        'Description: ${job.name}';
+    var jobName = 'SDK: ${job.sdk} - '
+        'DIR: ${job.package} - '
+        'TASKS: ${job.name}';
     buffer.writeln('''
     - stage: ${job.stageName}
       name: "$jobName"

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -305,8 +305,11 @@ String _listJobs(Iterable<TravisJob> jobs, Map<String, String> commandsToKeys) {
   for (var job in jobs) {
     var commands =
         job.tasks.map((task) => commandsToKeys[task.command]).join(' ');
+    buffer.writeln('    - stage: ${job.stageName}');
+    if (job.name != null) {
+      buffer.writeln('      name: "${job.package}: ${job.name}"');
+    }
     buffer.writeln('''
-    - stage: ${job.stageName}
       script: ./tool/travis.sh $commands
       env: PKG="${job.package}"
       dart: ${job.sdk}''');

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -305,11 +305,9 @@ String _listJobs(Iterable<TravisJob> jobs, Map<String, String> commandsToKeys) {
   for (var job in jobs) {
     var commands =
         job.tasks.map((task) => commandsToKeys[task.command]).join(' ');
-    buffer.writeln('    - stage: ${job.stageName}');
-    if (job.name != null) {
-      buffer.writeln('      name: "${job.package}: ${job.name}"');
-    }
     buffer.writeln('''
+    - stage: ${job.stageName}
+      name: "Dart: ${job.sdk}   Package: ${job.package}   Description: ${job.name}"
       script: ./tool/travis.sh $commands
       env: PKG="${job.package}"
       dart: ${job.sdk}''');

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -307,7 +307,7 @@ String _listJobs(Iterable<TravisJob> jobs, Map<String, String> commandsToKeys) {
         job.tasks.map((task) => commandsToKeys[task.command]).join(' ');
     buffer.writeln('''
     - stage: ${job.stageName}
-      name: "**Dart:** ${job.sdk} **Package:** ${job.package} **Description**: ${job.name}"
+      name: "Dart SDK: ${job.sdk}\nDirectory: ${job.package}\nDescription: ${job.name}"
       script: ./tool/travis.sh $commands
       env: PKG="${job.package}"
       dart: ${job.sdk}''');

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -307,7 +307,7 @@ String _listJobs(Iterable<TravisJob> jobs, Map<String, String> commandsToKeys) {
         job.tasks.map((task) => commandsToKeys[task.command]).join(' ');
     buffer.writeln('''
     - stage: ${job.stageName}
-      name: "<strong>Dart:</strong> ${job.sdk} <strong>Package:</strong> ${job.package} <strong>Description</<strong>: ${job.name}"
+      name: "**Dart:** ${job.sdk} **Package:** ${job.package} **Description**: ${job.name}"
       script: ./tool/travis.sh $commands
       env: PKG="${job.package}"
       dart: ${job.sdk}''');

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -307,7 +307,7 @@ String _listJobs(Iterable<TravisJob> jobs, Map<String, String> commandsToKeys) {
         job.tasks.map((task) => commandsToKeys[task.command]).join(' ');
     buffer.writeln('''
     - stage: ${job.stageName}
-      name: "Dart: ${job.sdk}   Package: ${job.package}   Description: ${job.name}"
+      name: "<strong>Dart:</strong> ${job.sdk} <strong>Package:</strong> ${job.package} <strong>Description</<strong>: ${job.name}"
       script: ./tool/travis.sh $commands
       env: PKG="${job.package}"
       dart: ${job.sdk}''');

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -53,6 +53,7 @@ class MonoConfig {
 @JsonSerializable()
 class TravisJob extends Object with _$TravisJobSerializerMixin {
   @override
+  @JsonKey(includeIfNull: false)
   final String description;
 
   @override

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -68,7 +68,8 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
   final List<Task> tasks;
 
   /// The description of the job to use for the job in the travis dashboard.
-  String get name => description ?? tasks.map((t) => t.command).join(', ');
+  String get name =>
+      description ?? tasks.map((t) => t.command).toList().toString();
 
   TravisJob(this.package, this.sdk, this.stageName, this.tasks,
       {this.description});

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -53,7 +53,7 @@ class MonoConfig {
 @JsonSerializable()
 class TravisJob extends Object with _$TravisJobSerializerMixin {
   @override
-  final String name;
+  final String description;
 
   @override
   final String package;
@@ -67,20 +67,25 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
   @override
   final List<Task> tasks;
 
-  TravisJob(this.package, this.sdk, this.stageName, this.tasks, {this.name});
+  /// The description of the job to use for the job in the travis dashboard.
+  String get name => description ?? tasks.map((t) => t.command).join(', ');
+
+  TravisJob(this.package, this.sdk, this.stageName, this.tasks,
+      {this.description});
 
   factory TravisJob.fromJson(Map<String, dynamic> json) =>
       _$TravisJobFromJson(json);
 
   factory TravisJob.parse(
       String package, String sdk, String stageName, Object yaml) {
-    String name;
-    if (yaml is Map && yaml.containsKey('name')) {
+    String description;
+    if (yaml is Map && yaml.containsKey('description')) {
       yaml = new Map.of(yaml as Map);
-      name = (yaml as Map).remove('name') as String;
+      description = (yaml as Map).remove('description') as String;
     }
-    return new TravisJob(package, sdk, stageName, Task.parseTaskOrGroup(yaml),
-        name: name);
+    var tasks = Task.parseTaskOrGroup(yaml);
+    return new TravisJob(package, sdk, stageName, tasks,
+        description: description);
   }
 
   @override
@@ -90,7 +95,7 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
   @override
   int get hashCode => _equality.hash(_items);
 
-  List get _items => [name, package, sdk, stageName, tasks];
+  List get _items => [description, package, sdk, stageName, tasks];
 }
 
 @JsonSerializable(includeIfNull: false)

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -53,6 +53,9 @@ class MonoConfig {
 @JsonSerializable()
 class TravisJob extends Object with _$TravisJobSerializerMixin {
   @override
+  final String name;
+
+  @override
   final String package;
 
   @override
@@ -64,14 +67,21 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
   @override
   final List<Task> tasks;
 
-  TravisJob(this.package, this.sdk, this.stageName, this.tasks);
+  TravisJob(this.package, this.sdk, this.stageName, this.tasks, {this.name});
 
   factory TravisJob.fromJson(Map<String, dynamic> json) =>
       _$TravisJobFromJson(json);
 
   factory TravisJob.parse(
-          String package, String sdk, String stageName, Object yaml) =>
-      new TravisJob(package, sdk, stageName, Task.parseTaskOrGroup(yaml));
+      String package, String sdk, String stageName, Object yaml) {
+    String name;
+    if (yaml is Map && yaml.containsKey('name')) {
+      yaml = new Map.of(yaml as Map);
+      name = (yaml as Map).remove('name') as String;
+    }
+    return new TravisJob(package, sdk, stageName, Task.parseTaskOrGroup(yaml),
+        name: name);
+  }
 
   @override
   bool operator ==(Object other) =>
@@ -80,7 +90,7 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
   @override
   int get hashCode => _equality.hash(_items);
 
-  List get _items => [sdk, tasks];
+  List get _items => [name, package, sdk, stageName, tasks];
 }
 
 @JsonSerializable(includeIfNull: false)

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -69,7 +69,10 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
 
   /// The description of the job to use for the job in the travis dashboard.
   String get name =>
-      description ?? tasks.map((t) => t.command).toList().toString();
+      description ??
+      (tasks.length > 1
+          ? tasks.map((t) => t.command).toList().toString()
+          : tasks.first.command);
 
   TravisJob(this.package, this.sdk, this.stageName, this.tasks,
       {this.description});

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -83,11 +83,14 @@ class TravisJob extends Object with _$TravisJobSerializerMixin {
   factory TravisJob.parse(
       String package, String sdk, String stageName, Object yaml) {
     String description;
+    dynamic withoutDescription;
     if (yaml is Map && yaml.containsKey('description')) {
-      yaml = new Map.of(yaml as Map);
-      description = (yaml as Map).remove('description') as String;
+      withoutDescription = new Map.of(yaml);
+      description = withoutDescription.remove('description') as String;
+    } else {
+      withoutDescription = yaml;
     }
-    var tasks = Task.parseTaskOrGroup(yaml);
+    var tasks = Task.parseTaskOrGroup(withoutDescription);
     return new TravisJob(package, sdk, stageName, tasks,
         description: description);
   }

--- a/mono_repo/lib/src/mono_config.g.dart
+++ b/mono_repo/lib/src/mono_config.g.dart
@@ -35,13 +35,22 @@ abstract class _$TravisJobSerializerMixin {
   String get sdk;
   String get stageName;
   List<Task> get tasks;
-  Map<String, dynamic> toJson() => <String, dynamic>{
-        'description': description,
-        'package': package,
-        'sdk': sdk,
-        'stageName': stageName,
-        'tasks': tasks
-      };
+  Map<String, dynamic> toJson() {
+    var val = <String, dynamic>{};
+
+    void writeNotNull(String key, dynamic value) {
+      if (value != null) {
+        val[key] = value;
+      }
+    }
+
+    writeNotNull('description', description);
+    val['package'] = package;
+    val['sdk'] = sdk;
+    val['stageName'] = stageName;
+    val['tasks'] = tasks;
+    return val;
+  }
 }
 
 Task _$TaskFromJson(Map json) {

--- a/mono_repo/lib/src/mono_config.g.dart
+++ b/mono_repo/lib/src/mono_config.g.dart
@@ -24,19 +24,19 @@ TravisJob _$TravisJobFromJson(Map json) {
                     ? null
                     : new Task.fromJson(e as Map<String, dynamic>))
                 ?.toList()),
-        name: $checkedConvert(json, 'name', (v) => v as String));
+        description: $checkedConvert(json, 'description', (v) => v as String));
     return val;
   });
 }
 
 abstract class _$TravisJobSerializerMixin {
-  String get name;
+  String get description;
   String get package;
   String get sdk;
   String get stageName;
   List<Task> get tasks;
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'name': name,
+        'description': description,
         'package': package,
         'sdk': sdk,
         'stageName': stageName,

--- a/mono_repo/lib/src/mono_config.g.dart
+++ b/mono_repo/lib/src/mono_config.g.dart
@@ -23,17 +23,20 @@ TravisJob _$TravisJobFromJson(Map json) {
                 ?.map((e) => e == null
                     ? null
                     : new Task.fromJson(e as Map<String, dynamic>))
-                ?.toList()));
+                ?.toList()),
+        name: $checkedConvert(json, 'name', (v) => v as String));
     return val;
   });
 }
 
 abstract class _$TravisJobSerializerMixin {
+  String get name;
   String get package;
   String get sdk;
   String get stageName;
   List<Task> get tasks;
   Map<String, dynamic> toJson() => <String, dynamic>{
+        'name': name,
         'package': package,
         'sdk': sdk,
         'stageName': stageName,

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -258,6 +258,7 @@ line 12, column 7: Stages muts be unique. "a" appears more than once.
 
 List get _testConfig1expectedOutput => [
       {
+        "description": "dartanalyzer && dartfmt",
         "package": "a",
         "sdk": "dev",
         "stageName": "analyze_and_format",

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -97,7 +97,8 @@ dart:
 
 stages:
   - analyze_and_format:
-    - group:
+    - description: "dartanalyzer && dartfmt"
+      group:
         - dartanalyzer: --fatal-infos --fatal-warnings .
         - dartfmt
       dart:
@@ -131,7 +132,8 @@ stages:
       dart:
         - 1.23.0
   - unit_test:
-    - test: --platform chrome
+    - description: "chrome tests"
+      test: --platform chrome
     - test: --preset travis --total-shards 9 --shard-index 0
     - test: --preset travis --total-shards 9 --shard-index 1
     - test: --preset travis --total-shards 9 --shard-index 2

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -359,17 +359,17 @@ jobs:
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
-      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --platform chrome"
+      name: "SDK: dev - DIR: sub_pkg - TASKS: chrome tests"
       script: ./tool/travis.sh test_00
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
-      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --platform chrome"
+      name: "SDK: stable - DIR: sub_pkg - TASKS: chrome tests"
       script: ./tool/travis.sh test_00
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
-      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --platform chrome"
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: chrome tests"
       script: ./tool/travis.sh test_00
       env: PKG="sub_pkg"
       dart: 1.23.0

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -174,14 +174,17 @@ language: dart
 jobs:
   include:
     - stage: format
+      name: "SDK: stable - DIR: pkg_a - TASKS: dartfmt -n --set-exit-if-changed ."
       script: ./tool/travis.sh dartfmt
       env: PKG="pkg_a"
       dart: stable
     - stage: format
+      name: "SDK: dev - DIR: pkg_a - TASKS: dartfmt -n --set-exit-if-changed ."
       script: ./tool/travis.sh dartfmt
       env: PKG="pkg_a"
       dart: dev
     - stage: format
+      name: "SDK: dev - DIR: pkg_b - TASKS: dartfmt -n --set-exit-if-changed ."
       script: ./tool/travis.sh dartfmt
       env: PKG="pkg_b"
       dart: dev
@@ -346,142 +349,177 @@ language: dart
 jobs:
   include:
     - stage: analyze
+      name: "SDK: dev - DIR: sub_pkg - TASKS: [dartanalyzer ., dartfmt -n --set-exit-if-changed .]"
       script: ./tool/travis.sh dartanalyzer dartfmt
       env: PKG="sub_pkg"
       dart: dev
     - stage: analyze
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: dartanalyzer ."
       script: ./tool/travis.sh dartanalyzer
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --platform chrome"
       script: ./tool/travis.sh test_00
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --platform chrome"
       script: ./tool/travis.sh test_00
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --platform chrome"
       script: ./tool/travis.sh test_00
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 0"
       script: ./tool/travis.sh test_01
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 0"
       script: ./tool/travis.sh test_01
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 0"
       script: ./tool/travis.sh test_01
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 1"
       script: ./tool/travis.sh test_02
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 1"
       script: ./tool/travis.sh test_02
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 1"
       script: ./tool/travis.sh test_02
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 2"
       script: ./tool/travis.sh test_03
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 2"
       script: ./tool/travis.sh test_03
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 2"
       script: ./tool/travis.sh test_03
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 3"
       script: ./tool/travis.sh test_04
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 3"
       script: ./tool/travis.sh test_04
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 3"
       script: ./tool/travis.sh test_04
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 4"
       script: ./tool/travis.sh test_05
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 4"
       script: ./tool/travis.sh test_05
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 4"
       script: ./tool/travis.sh test_05
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 5"
       script: ./tool/travis.sh test_06
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 5"
       script: ./tool/travis.sh test_06
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 5"
       script: ./tool/travis.sh test_06
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 6"
       script: ./tool/travis.sh test_07
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 6"
       script: ./tool/travis.sh test_07
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 6"
       script: ./tool/travis.sh test_07
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 7"
       script: ./tool/travis.sh test_08
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 7"
       script: ./tool/travis.sh test_08
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 7"
       script: ./tool/travis.sh test_08
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 8"
       script: ./tool/travis.sh test_09
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 8"
       script: ./tool/travis.sh test_09
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test --preset travis --total-shards 9 --shard-index 8"
       script: ./tool/travis.sh test_09
       env: PKG="sub_pkg"
       dart: 1.23.0
     - stage: unit_test
+      name: "SDK: dev - DIR: sub_pkg - TASKS: pub run test"
       script: ./tool/travis.sh test_10
       env: PKG="sub_pkg"
       dart: dev
     - stage: unit_test
+      name: "SDK: stable - DIR: sub_pkg - TASKS: pub run test"
       script: ./tool/travis.sh test_10
       env: PKG="sub_pkg"
       dart: stable
     - stage: unit_test
+      name: "SDK: 1.23.0 - DIR: sub_pkg - TASKS: pub run test"
       script: ./tool/travis.sh test_10
       env: PKG="sub_pkg"
       dart: 1.23.0


### PR DESCRIPTION
Adds custom names for jobs on travis. By default the name looks like:

```
SDK: <version> - DIR: <directory> - TASKS: <all task commands being ran>
```

The part after `TASKS` is configurable via an extra key `description` on the job config.