### PR TITLE
update presubmit task descriptions to include the actual command

### DIFF
--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+* Improve presubmit command output to list the full command for each task
+  instead of the name of the task type only.
+
 ## 1.0.0
 
 * Add support for configuring top-level Travis options via `mono_repo.yaml`.
@@ -7,7 +12,7 @@
 * The root `mono_config.yaml` file is no longer used to configure which packages
   are configured. Instead, `mono_pkg.yaml` is required to be in each target
   package directory. A package is considered published if it has a value for
-  `version` in `pubspec.yaml`. 
+  `version` in `pubspec.yaml`.
 
 * The package configuration file is now `mono_pkg.yaml`. If a legacy config file
   – `.mono_repo.yml` – is found, the command is canceled and a warning is

--- a/mono_repo/lib/src/commands/presubmit.dart
+++ b/mono_repo/lib/src/commands/presubmit.dart
@@ -108,8 +108,8 @@ Future<bool> presubmit(RootConfig configs,
         // Skip tasks that weren't specified
         if (!tasks.contains(task.name)) continue;
 
-        stderr.write(
-            '  Running task ${styleBold.wrap(white.wrap('${task.name}:$sdk'))} ');
+        stderr.write('  SDK: ${styleBold.wrap(white.wrap(job.sdk))} '
+            'TASK: ${styleBold.wrap(white.wrap(task.command))} ');
         if (sdk != sdkToRun) {
           stderr.writeln(yellow.wrap('(skipped, mismatched sdk)'));
           continue;

--- a/mono_repo/lib/src/mono_config.g.dart
+++ b/mono_repo/lib/src/mono_config.g.dart
@@ -9,14 +9,14 @@ part of 'mono_config.dart';
 ConditionalStage _$ConditionalStageFromJson(Map json) {
   return $checkedNew('ConditionalStage', json, () {
     $checkKeys(json,
-        allowedKeys: ['name', 'if'],
-        requiredKeys: ['name', 'if'],
-        disallowNullValues: ['name', 'if']);
+        allowedKeys: const ['name', 'if'],
+        requiredKeys: const ['name', 'if'],
+        disallowNullValues: const ['name', 'if']);
     var val = ConditionalStage(
         $checkedConvert(json, 'name', (v) => v as String),
         $checkedConvert(json, 'if', (v) => v as String));
     return val;
-  }, fieldKeyMap: {'ifCondition': 'if'});
+  }, fieldKeyMap: const {'ifCondition': 'if'});
 }
 
 Map<String, dynamic> _$ConditionalStageToJson(ConditionalStage instance) {

--- a/mono_repo/lib/src/raw_config.g.dart
+++ b/mono_repo/lib/src/raw_config.g.dart
@@ -8,7 +8,7 @@ part of 'raw_config.dart';
 
 RawConfig _$RawConfigFromJson(Map json) {
   return $checkedNew('RawConfig', json, () {
-    $checkKeys(json, allowedKeys: ['dart', 'stages', 'cache']);
+    $checkKeys(json, allowedKeys: const ['dart', 'stages', 'cache']);
     var val = RawConfig(
         $checkedConvert(json, 'dart',
             (v) => (v as List)?.map((e) => e as String)?.toList()),
@@ -21,7 +21,7 @@ RawConfig _$RawConfigFromJson(Map json) {
         $checkedConvert(json, 'cache',
             (v) => v == null ? null : RawCache.fromJson(v as Map)));
     return val;
-  }, fieldKeyMap: {'sdks': 'dart'});
+  }, fieldKeyMap: const {'sdks': 'dart'});
 }
 
 RawCache _$RawCacheFromJson(Map json) {

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mono_repo
 description: Manage repositories with multiple Dart packages
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/dart-lang/mono_repo
 author: Dart Team <misc@dartlang.org>
 

--- a/mono_repo/test/presubmit_command_test.dart
+++ b/mono_repo/test/presubmit_command_test.dart
@@ -83,15 +83,15 @@ void main() {
           reason: 'stderr:\n${result.stderr}\nstdout:\n${result.stdout}');
       expect(result.stderr, '''
 pkg_a
-  Running task dartanalyzer:dev (success)
-  Running task dartanalyzer:stable (skipped, mismatched sdk)
-  Running task dartfmt:dev (success)
-  Running task dartfmt:stable (skipped, mismatched sdk)
-  Running task test:dev (success)
-  Running task test:stable (skipped, mismatched sdk)
+  SDK: dev TASK: dartanalyzer . (success)
+  SDK: stable TASK: dartanalyzer . (skipped, mismatched sdk)
+  SDK: dev TASK: dartfmt -n --set-exit-if-changed . (success)
+  SDK: stable TASK: dartfmt -n --set-exit-if-changed . (skipped, mismatched sdk)
+  SDK: dev TASK: pub run test (success)
+  SDK: stable TASK: pub run test (skipped, mismatched sdk)
 pkg_b
-  Running task dartfmt:dev (success)
-  Running task dartfmt:stable (skipped, mismatched sdk)
+  SDK: dev TASK: dartfmt -n --set-exit-if-changed . (success)
+  SDK: stable TASK: dartfmt -n --set-exit-if-changed . (skipped, mismatched sdk)
 ''');
     }, timeout: const Timeout.factor(2));
 
@@ -112,8 +112,8 @@ pkg_b
           reason: 'stderr:\n${result.stderr}\nstdout:\n${result.stdout}');
       expect(result.stderr, '''
 pkg_b
-  Running task dartfmt:dev (success)
-  Running task dartfmt:stable (skipped, mismatched sdk)
+  SDK: dev TASK: dartfmt -n --set-exit-if-changed . (success)
+  SDK: stable TASK: dartfmt -n --set-exit-if-changed . (skipped, mismatched sdk)
 ''');
     });
 
@@ -134,11 +134,11 @@ pkg_b
           reason: 'stderr:\n${result.stderr}\nstdout:\n${result.stdout}');
       expect(result.stderr, '''
 pkg_a
-  Running task dartfmt:dev (success)
-  Running task dartfmt:stable (skipped, mismatched sdk)
+  SDK: dev TASK: dartfmt -n --set-exit-if-changed . (success)
+  SDK: stable TASK: dartfmt -n --set-exit-if-changed . (skipped, mismatched sdk)
 pkg_b
-  Running task dartfmt:dev (success)
-  Running task dartfmt:stable (skipped, mismatched sdk)
+  SDK: dev TASK: dartfmt -n --set-exit-if-changed . (success)
+  SDK: stable TASK: dartfmt -n --set-exit-if-changed . (skipped, mismatched sdk)
 ''');
     });
 
@@ -173,7 +173,7 @@ pkg_b
             reason: 'Any failing tasks should give a non-zero exit code');
         expect(result.stderr, startsWith('''
 pkg_a
-  Running task test:dev (failure, '''));
+  SDK: dev TASK: pub run test (failure, '''));
         var stdErrString = result.stderr as String;
         var start = stdErrString.indexOf('(failure, ') + 10;
         var end = stdErrString.indexOf(')');
@@ -193,7 +193,7 @@ dart:
 
 stages:
   - analyze_and_format:
-    - dartanalyzer 
+    - dartanalyzer
     - dartfmt
   - unit_test:
     - test


### PR DESCRIPTION
Essentially, this now much more closely resembles the description you see in travis, and has a lot more information.

For anything which used the `command` task before, that is all it would show (not the actual command), which wasn't useful. It also wouldn't show any args passed to the other tasks.