### PR TITLE
Avoid throwing in `prettyPrintCheckedFromJsonException`

### DIFF
--- a/mono_repo/lib/src/root_config.dart
+++ b/mono_repo/lib/src/root_config.dart
@@ -51,8 +51,12 @@ PackageConfig _packageConfigFromDir(
   try {
     config = new PackageConfig.parse(pkgRelativePath, pubspec, pkgConfigYaml);
   } on CheckedFromJsonException catch (e) {
+    var details = prettyPrintCheckedFromJsonException(e);
+    if (details == null) {
+      rethrow;
+    }
     throw new UserException('Error parsing $pkgRelativePath/$monoPkgFileName',
-        details: prettyPrintCheckedFromJsonException(e));
+        details: details);
   }
 
   // TODO(kevmoo): Now that we can write yaml, we should support round-tripping

--- a/mono_repo/lib/src/yaml.dart
+++ b/mono_repo/lib/src/yaml.dart
@@ -15,6 +15,9 @@ final _yamlMapExpando = new Expando<y.YamlMap>('yamlMap');
 
 String prettyPrintCheckedFromJsonException(CheckedFromJsonException err) {
   var yamlMap = _yamlMapExpando[err.map];
+  if (yamlMap == null) {
+    return null;
+  }
 
   y.YamlScalar _getYamlKey(String key) => yamlMap.nodes.keys
       .cast<y.YamlScalar>()


### PR DESCRIPTION
rethrow doesn't give a much better error, but it does give a better stack