### PR TITLE
Improve style generated `tool/travis.sh` script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v1.2.2
+# Created with package:mono_repo v1.2.3-dev
 language: dart
 
 jobs:

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.2.3
 
+* Improve style of the generated `tool/travis.sh` script, including fast-failing
+  if the `PKG` variable does not map to an existing directory.
 * Require at least Dart 2.1.0.
 * The `dart` key is no longer required in `mono_pkg.yaml` if all stages specify
   their own values. A warning is printed if values are provided but not used.

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -179,7 +179,7 @@ void _logPkgs(Iterable<PackageConfig> configs) {
 String _shellCase(String scriptVariable, List<String> entries) {
   if (entries.isEmpty) return '';
   return '''
-  case \$$scriptVariable in
+  case \${$scriptVariable} in
 ${entries.join('\n')}
   esac
 ''';
@@ -189,17 +189,17 @@ String _travisSh(List<String> tasks, bool prettyAnsi, String pkgVersion) => '''
 #!/bin/bash
 # ${_createdWith(pkgVersion)}
 
-if [ -z "\$PKG" ]; then
+if [[ -z \${PKG} ]]; then
   ${safeEcho(prettyAnsi, red, "PKG environment variable must be set!")}
   exit 1
 fi
 
-if [ "\$#" == "0" ]; then
+if [[ "\$#" == "0" ]]; then
   ${safeEcho(prettyAnsi, red, "At least one task argument must be provided!")}
   exit 1
 fi
 
-pushd \$PKG
+pushd \${PKG} || exit \$?
 pub upgrade || exit \$?
 
 EXIT_CODE=0
@@ -210,7 +210,7 @@ ${_shellCase('TASK', tasks)}
   shift
 done
 
-exit \$EXIT_CODE
+exit \${EXIT_CODE}
 ''';
 
 String _travisYml(

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -93,24 +93,24 @@ final _travisSh = r'''
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-if [ -z "$PKG" ]; then
+if [[ -z ${PKG} ]]; then
   echo -e '\033[31mPKG environment variable must be set!\033[0m'
   exit 1
 fi
 
-if [ "$#" == "0" ]; then
+if [[ "$#" == "0" ]]; then
   echo -e '\033[31mAt least one task argument must be provided!\033[0m'
   exit 1
 fi
 
-pushd $PKG
+pushd ${PKG} || exit $?
 pub upgrade || exit $?
 
 EXIT_CODE=0
 
 while (( "$#" )); do
   TASK=$1
-  case $TASK in
+  case ${TASK} in
   dartanalyzer) echo
     echo -e '\033[1mTASK: dartanalyzer\033[22m'
     echo -e 'dartanalyzer .'
@@ -134,5 +134,5 @@ while (( "$#" )); do
   shift
 done
 
-exit $EXIT_CODE
+exit ${EXIT_CODE}
 ''';

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -243,24 +243,24 @@ cache:
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-if [ -z "$PKG" ]; then
+if [[ -z ${PKG} ]]; then
   echo -e '\033[31mPKG environment variable must be set!\033[0m'
   exit 1
 fi
 
-if [ "$#" == "0" ]; then
+if [[ "$#" == "0" ]]; then
   echo -e '\033[31mAt least one task argument must be provided!\033[0m'
   exit 1
 fi
 
-pushd $PKG
+pushd ${PKG} || exit $?
 pub upgrade || exit $?
 
 EXIT_CODE=0
 
 while (( "$#" )); do
   TASK=$1
-  case $TASK in
+  case ${TASK} in
   dartfmt) echo
     echo -e '\033[1mTASK: dartfmt\033[22m'
     echo -e 'dartfmt -n --set-exit-if-changed .'
@@ -274,7 +274,7 @@ while (( "$#" )); do
   shift
 done
 
-exit $EXIT_CODE
+exit ${EXIT_CODE}
 ''').validate();
   });
 
@@ -361,24 +361,24 @@ cache:
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-if [ -z "$PKG" ]; then
+if [[ -z ${PKG} ]]; then
   echo -e '\033[31mPKG environment variable must be set!\033[0m'
   exit 1
 fi
 
-if [ "$#" == "0" ]; then
+if [[ "$#" == "0" ]]; then
   echo -e '\033[31mAt least one task argument must be provided!\033[0m'
   exit 1
 fi
 
-pushd $PKG
+pushd ${PKG} || exit $?
 pub upgrade || exit $?
 
 EXIT_CODE=0
 
 while (( "$#" )); do
   TASK=$1
-  case $TASK in
+  case ${TASK} in
   dartanalyzer_0) echo
     echo -e '\033[1mTASK: dartanalyzer_0\033[22m'
     echo -e 'dartanalyzer --fatal-warnings --fatal-infos .'
@@ -402,7 +402,7 @@ while (( "$#" )); do
   shift
 done
 
-exit $EXIT_CODE
+exit ${EXIT_CODE}
 ''').validate();
   });
 
@@ -630,24 +630,24 @@ final _config2Shell = r"""
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-if [ -z "$PKG" ]; then
+if [[ -z ${PKG} ]]; then
   echo -e '\033[31mPKG environment variable must be set!\033[0m'
   exit 1
 fi
 
-if [ "$#" == "0" ]; then
+if [[ "$#" == "0" ]]; then
   echo -e '\033[31mAt least one task argument must be provided!\033[0m'
   exit 1
 fi
 
-pushd $PKG
+pushd ${PKG} || exit $?
 pub upgrade || exit $?
 
 EXIT_CODE=0
 
 while (( "$#" )); do
   TASK=$1
-  case $TASK in
+  case ${TASK} in
   dartanalyzer) echo
     echo -e '\033[1mTASK: dartanalyzer\033[22m'
     echo -e 'dartanalyzer .'
@@ -721,7 +721,7 @@ while (( "$#" )); do
   shift
 done
 
-exit $EXIT_CODE
+exit ${EXIT_CODE}
 """;
 
 final _config2Yaml = r'''

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
-# Created with package:mono_repo v1.2.2
+# Created with package:mono_repo v1.2.3-dev
 
-if [ -z "$PKG" ]; then
+if [[ -z ${PKG} ]]; then
   echo -e '\033[31mPKG environment variable must be set!\033[0m'
   exit 1
 fi
 
-if [ "$#" == "0" ]; then
+if [[ "$#" == "0" ]]; then
   echo -e '\033[31mAt least one task argument must be provided!\033[0m'
   exit 1
 fi
 
-pushd $PKG
+pushd ${PKG} || exit $?
 pub upgrade || exit $?
 
 EXIT_CODE=0
 
 while (( "$#" )); do
   TASK=$1
-  case $TASK in
+  case ${TASK} in
   command_0) echo
     echo -e '\033[1mTASK: command_0\033[22m'
     echo -e 'pub run build_runner build test --delete-conflicting-outputs'
@@ -57,4 +57,4 @@ while (( "$#" )); do
   shift
 done
 
-exit $EXIT_CODE
+exit ${EXIT_CODE}


### PR DESCRIPTION
Wrapping non-standard vars with {} to emphasize they are not standard
globals

Use more modern [[]] syntax for tests

fast-fail if the `PKG` variable does not map to an existing directory