### PR TITLE
Quote variable for `pushd`

### DIFF
--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -199,7 +199,7 @@ if [[ "\$#" == "0" ]]; then
   exit 1
 fi
 
-pushd \${PKG} || exit \$?
+pushd "\${PKG}" || exit \$?
 pub upgrade || exit \$?
 
 EXIT_CODE=0

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -107,7 +107,7 @@ EXIT_CODE=0
 
 for PKG in ${PKGS}; do
   echo -e "\033[1mPKG: ${PKG}\033[22m"
-  pushd ${PKG} || exit $?
+  pushd "${PKG}" || exit $?
   pub upgrade --no-precompile || exit $?
 
   for TASK in "$@"; do

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -257,7 +257,7 @@ EXIT_CODE=0
 
 for PKG in ${PKGS}; do
   echo -e "\033[1mPKG: ${PKG}\033[22m"
-  pushd ${PKG} || exit $?
+  pushd "${PKG}" || exit $?
   pub upgrade --no-precompile || exit $?
 
   for TASK in "$@"; do
@@ -377,7 +377,7 @@ EXIT_CODE=0
 
 for PKG in ${PKGS}; do
   echo -e "\033[1mPKG: ${PKG}\033[22m"
-  pushd ${PKG} || exit $?
+  pushd "${PKG}" || exit $?
   pub upgrade --no-precompile || exit $?
 
   for TASK in "$@"; do
@@ -648,7 +648,7 @@ EXIT_CODE=0
 
 for PKG in ${PKGS}; do
   echo -e "\033[1mPKG: ${PKG}\033[22m"
-  pushd ${PKG} || exit $?
+  pushd "${PKG}" || exit $?
   pub upgrade --no-precompile || exit $?
 
   for TASK in "$@"; do


### PR DESCRIPTION
Other references to variables are safe. It's unlikely for `PKG` to
contain a space, but this is safer than unquoted.