### PR TITLE
Allow args to be passed to dartfmt

### DIFF
--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -3,6 +3,11 @@
 - Fix issue where `pub` command failing for one package stops test run for
   other packages grouped into the same Travis task.
 - Use `flutter packages` for `pub` command on packages that depend on Flutter.
+- Any arguments given to `dartfmt` Travis tasks are used instead of the default 
+`-n --set-exit-if-changed .`.
+  - To maintain previous behavior, `dartfmt: sdk` is a special case and still
+  triggers the default arguments.
+
 
 ## 2.1.0
 

--- a/mono_repo/lib/src/package_config.dart
+++ b/mono_repo/lib/src/package_config.dart
@@ -269,8 +269,10 @@ class Task {
   String get command {
     switch (name) {
       case 'dartfmt':
-        assert(args == null || args == 'sdk');
-        return 'dartfmt -n --set-exit-if-changed .';
+        if (args == null || args == 'sdk') {
+          return 'dartfmt -n --set-exit-if-changed .';
+        }
+        return 'dartfmt $args';
       case 'dartanalyzer':
         if (args == null) {
           return 'dartanalyzer .';

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -317,6 +317,148 @@ exit ${EXIT_CODE}
 ''').validate();
   });
 
+  test('two flavors of dartfmt with different arguments', () async {
+    await d.dir('pkg_a', [
+      d.file(monoPkgFileName, r'''
+dart:
+ - stable
+ - dev
+
+stages:
+  - format:
+    - dartfmt: sdk
+
+cache:
+  directories:
+    - .dart_tool
+    - /some_repo_root_dir
+'''),
+      d.file('pubspec.yaml', '''
+name: pkg_a
+      ''')
+    ]).create();
+
+    await d.dir('pkg_b', [
+      d.file(monoPkgFileName, r'''
+dart:
+ - dev
+
+stages:
+  - format:
+    - dartfmt: --dry-run --fix --set-exit-if-changed .
+
+cache:
+  directories:
+    - .dart_tool
+    - /some_repo_root_dir
+'''),
+      d.file('pubspec.yaml', '''
+name: pkg_b
+      ''')
+    ]).create();
+
+    await expectLater(
+        testGenerateTravisConfig,
+        prints(stringContainsInOrder([
+          'package:pkg_a',
+          'package:pkg_b',
+          'Make sure to mark `./tool/travis.sh` as executable.'
+        ])));
+
+    await d.file(travisFileName, r'''
+# Created with package:mono_repo v1.2.3
+language: dart
+
+jobs:
+  include:
+    - stage: format
+      name: "SDK: dev; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      dart: dev
+      env: PKGS="pkg_a"
+      script: ./tool/travis.sh dartfmt
+    - stage: format
+      name: "SDK: stable; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      dart: stable
+      env: PKGS="pkg_a"
+      script: ./tool/travis.sh dartfmt
+    - stage: format
+      name: "SDK: dev; PKG: pkg_b; TASKS: `dartfmt --dry-run --fix --set-exit-if-changed .`"
+      dart: dev
+      env: PKGS="pkg_b"
+      script: ./tool/travis.sh dartfmt
+
+stages:
+  - format
+
+# Only building master means that we don't run two builds for each pull request.
+branches:
+  only:
+    - master
+
+cache:
+  directories:
+    - "$HOME/.pub-cache"
+    - /some_repo_root_dir
+    - pkg_a/.dart_tool
+    - pkg_b/.dart_tool
+''').validate();
+
+    await d.file(travisShPath, r'''
+#!/bin/bash
+# Created with package:mono_repo v1.2.3
+
+if [[ -z ${PKGS} ]]; then
+  echo -e '\033[31mPKGS environment variable must be set!\033[0m'
+  exit 1
+fi
+
+if [[ "$#" == "0" ]]; then
+  echo -e '\033[31mAt least one task argument must be provided!\033[0m'
+  exit 1
+fi
+
+EXIT_CODE=0
+
+for PKG in ${PKGS}; do
+  echo -e "\033[1mPKG: ${PKG}\033[22m"
+  pushd "${PKG}" || exit $?
+
+  PUB_EXIT_CODE=0
+  pub upgrade --no-precompile || PUB_EXIT_CODE=$?
+
+  if [[ ${PUB_EXIT_CODE} -ne 0 ]]; then
+    EXIT_CODE=1
+    echo -e '\033[31mpub upgrade failed\033[0m'
+    popd
+    continue
+  fi
+
+  for TASK in "$@"; do
+    echo
+    echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
+    case ${TASK} in
+    dartfmt_0)
+      echo 'dartfmt -n --set-exit-if-changed .'
+      dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
+      ;;
+    dartfmt_1)
+      echo 'dartfmt --dry-run --fix --set-exit-if-changed .'
+      dartfmt --dry-run --fix --set-exit-if-changed . || EXIT_CODE=$?
+      ;;
+    *)
+      echo -e "\033[31mNot expecting TASK '${TASK}'. Error!\033[0m"
+      EXIT_CODE=1
+      ;;
+    esac
+  done
+
+  popd
+done
+
+exit ${EXIT_CODE}
+''').validate();
+  });
+
   test('missing `dart` key', () async {
     await d.dir('pkg_a', [
       d.file(monoPkgFileName, r'''

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -375,17 +375,17 @@ jobs:
       name: "SDK: dev; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: dev
       env: PKGS="pkg_a"
-      script: ./tool/travis.sh dartfmt
+      script: ./tool/travis.sh dartfmt_0
     - stage: format
       name: "SDK: stable; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: stable
       env: PKGS="pkg_a"
-      script: ./tool/travis.sh dartfmt
+      script: ./tool/travis.sh dartfmt_0
     - stage: format
       name: "SDK: dev; PKG: pkg_b; TASKS: `dartfmt --dry-run --fix --set-exit-if-changed .`"
       dart: dev
       env: PKGS="pkg_b"
-      script: ./tool/travis.sh dartfmt
+      script: ./tool/travis.sh dartfmt_1
 
 stages:
   - format


### PR DESCRIPTION
Addresses #111 by allowing any arguments to be passed to `dartfmt` Travis tasks, in a very similar manner to how `dartanalyzer` is handled.

Original in [`package_config.dart`](https://github.com/dart-lang/mono_repo/blob/944792e83e87d89c912afe2fbb53ecf87994b5fb/mono_repo/lib/src/package_config.dart#L271-L273):
```dart
      case 'dartfmt':
        assert(args == null || args == 'sdk');
        return 'dartfmt -n --set-exit-if-changed .';
```
[changed to](https://github.com/jack-r-warren/mono_repo/blob/8b74b109c73ec7b6a9a41410067bdf24da1624bb/mono_repo/lib/src/package_config.dart#L271-L275):
```dart
      case 'dartfmt':
        if (args == null || args == 'sdk') {
          return 'dartfmt -n --set-exit-if-changed .';
        }
        return 'dartfmt $args';
```

Shouldn't be a breaking change; a lack of arguments and `sdk` are handled same as before. All existing tests pass and I added a [new one](https://github.com/jack-r-warren/mono_repo/blob/8b74b109c73ec7b6a9a41410067bdf24da1624bb/mono_repo/test/travis_command_test.dart#L320-L460) for this functionality specifically. Also added a bullet to the changelog for 2.1.1 briefly documenting the change. Happy to make any adjustments!