### PR TITLE
Add Travis argument to use `get` for dependencies rather than `upgrade`

### DIFF
--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Fix issue where `pub` command failing for one package stops test run for
   other packages grouped into the same Travis task.
 - Use `flutter packages` for `pub` command on packages that depend on Flutter.
+- Add `--use-get` optional flag for the `travis` command to use `pub get` 
+  instead of `pub upgrade` in the generated script.
 
 ## 2.1.0
 

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -17,6 +17,20 @@ void testGenerateTravisConfig() async {
   });
 }
 
+/// Creates a function similar to [testGenerateTravisConfig], except with
+/// custom arguments gives to [generateTravisConfig].
+///
+/// If no arguments are given, the output should have the exact same behavior
+/// as [generateTravisConfig].
+Function testGenerateCustomTravisConfig(
+        {bool prettyAnsi = true,
+        bool useGet = false,
+        String pkgVersion = '1.2.3'}) =>
+    () => overrideAnsiOutput(false, () {
+          generateTravisConfig(RootConfig(rootDirectory: d.sandbox),
+              prettyAnsi: prettyAnsi, useGet: useGet, pkgVersion: pkgVersion);
+        });
+
 Matcher throwsUserExceptionWith(Object message, Object details) =>
     throwsA(const TypeMatcher<UserException>()
         .having((e) => e.message, 'message', message)

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -179,6 +179,28 @@ environment:
     await d.file(travisShPath, _config2Shell).validate();
   });
 
+  test('using `get` in place of `upgrade`', () async {
+    await d.dir('sub_pkg', [
+      d.file(monoPkgFileName, testConfig2),
+      d.file('pubspec.yaml', '''
+name: pkg_name
+      ''')
+    ]).create();
+
+    await expectLater(
+        testGenerateCustomTravisConfig(useGet: true),
+        prints(stringContainsInOrder([
+          'package:sub_pkg',
+          'Make sure to mark `./tool/travis.sh` as executable.'
+        ])));
+
+    // replacement isn't actually how useGet works, but it is a concise test
+    await d
+        .file(travisShPath, _config2Shell.replaceAll('upgrade', 'get'))
+        .validate();
+    await d.file(travisFileName, _config2Yaml).validate();
+  });
+
   test('two flavors of dartfmt', () async {
     await d.dir('pkg_a', [
       d.file(monoPkgFileName, r'''


### PR DESCRIPTION
New optional flag for the `travis` command, `--use-get`. If provided, `pub get` is used instead of the default `pub upgrade` in the generated `travis.sh` file.

Fixes #121