### PR TITLE
Add Windows note about a workaround for not having chmod

### DIFF
--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -86,6 +86,13 @@ void _writeTravisScript(String rootDirectory, List<String> taskEntries,
     travisScript.createSync(recursive: true);
     print(yellow.wrap('Make sure to mark `$travisShPath` as executable.'));
     print(yellow.wrap('  chmod +x $travisShPath'));
+    if (Platform.isWindows) {
+      print(yellow.wrap('It appears you are using Windows, and may not have '
+          'access to chmod.'));
+      print(yellow.wrap('If you are using git, the following will emulate the '
+          'Unix permissions change:'));
+      print(yellow.wrap('  git update-index --add --chmod=+x $travisShPath'));
+    }
   }
 
   travisScript


### PR DESCRIPTION
Fixes #163. When `dart:io` detects the platform as Windows, the reminder to make `travis.sh` executable has an extra note appended:
```text
Make sure to mark `./tool/travis.sh` as executable.
  chmod +x ./tool/travis.sh
It appears you are using Windows, and may not have access to chmod.
If you are using git, the following will emulate the Unix permissions change:
  git update-index --add --chmod=+x ./tool/travis.sh
```

My understanding is that testing this behavior would require creating a new test file restricted to Windows with [`@TestOn`](https://pub.dev/packages/test#restricting-tests-to-certain-platforms). Right now, a significant number of existing tests fail on Windows and a Windows-specific test wouldn't be run on Travis, so I don't know the utility of adding it. 

Similarly, I didn't modify the changelog since the change doesn't affect functionality. I'm happy to add either of those omissions; I just wanted to avoid over-engineering on my first pass.