### PR TITLE
Multi os support

### DIFF
--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.3.0
+
+- Add support for `os` configuration.
+  - This generally works in the same way as the `dart` sdk option, except
+    that it is not required.
+  - The default is to only run on `linux`.
+  - Supports a top level `os` list in `mono_pkg.yaml` files.
+  - Supports overriding the `os` per task.
+
 ## 2.2.0
 
 - Fix issue where `pub` command failing for one package stops test run for

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -317,6 +317,9 @@ ${toYaml({
           if (value == 0) {
             value = a['dart'].compareTo(b['dart']);
           }
+          if (value == 0) {
+            value = a['os'].compareTo(b['os']);
+          }
           return value;
         });
 
@@ -478,7 +481,7 @@ class _TravisJobEntry {
   @override
   int get hashCode => _equality.hash(_identityItems);
 
-  List get _identityItems => [job.stageName, job.sdk, commands, merge];
+  List get _identityItems => [job.os, job.stageName, job.sdk, commands, merge];
 }
 
 final _equality = const DeepCollectionEquality();

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -215,6 +215,29 @@ String _travisSh(List<String> tasks, bool prettyAnsi,
 #!/bin/bash
 # ${_createdWith(pkgVersion)}
 
+# Support built in commands on windows out of the box.
+function pub {
+       if [[ \$TRAVIS_OS_NAME == "windows" ]]; then
+        command pub.bat "\$@"
+    else
+        command pub "\$@"
+    fi
+}
+function dartfmt {
+       if [[ \$TRAVIS_OS_NAME == "windows" ]]; then
+        command dartfmt.bat "\$@"
+    else
+        command dartfmt "\$@"
+    fi
+}
+function dartanalyzer {
+       if [[ \$TRAVIS_OS_NAME == "windows" ]]; then
+        command dartanalyzer.bat "\$@"
+    else
+        command dartanalyzer "\$@"
+    fi
+}
+
 if [[ -z \${PKGS} ]]; then
   ${safeEcho(prettyAnsi, red, "PKGS environment variable must be set!")}
   exit 1

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -464,6 +464,7 @@ class _TravisJobEntry {
       'stage': job.stageName,
       'name': _jobName(packages),
       'dart': job.sdk,
+      'os': job.os,
       'env': 'PKGS="${packages.join(' ')}"',
       'script': './tool/travis.sh ${commands.join(' ')}',
     };

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -193,6 +193,10 @@ void _logPkgs(Iterable<PackageConfig> configs) {
       print(yellow.wrap('  `dart` values (${pkg.sdks.join(', ')}) are not used '
           'and can be removed.'));
     }
+    if (pkg.oses != null && !pkg.osConfigUsed) {
+      print(yellow.wrap('  `os` values (${pkg.oses.join(', ')}) are not used '
+          'and can be removed.'));
+    }
   }
 }
 

--- a/mono_repo/lib/src/package_config.dart
+++ b/mono_repo/lib/src/package_config.dart
@@ -19,20 +19,24 @@ class PackageConfig {
   final String relativePath;
   final Pubspec pubspec;
 
+  final List<String> oses;
   final List<String> sdks;
   final List<String> stageNames;
   final List<TravisJob> jobs;
   final List<String> cacheDirectories;
   final bool dartSdkConfigUsed;
+  final bool osConfigUsed;
 
   PackageConfig(
     this.relativePath,
     this.pubspec,
+    this.oses,
     this.sdks,
     this.stageNames,
     this.jobs,
     this.cacheDirectories,
     this.dartSdkConfigUsed,
+    this.osConfigUsed,
   );
 
   factory PackageConfig.parse(
@@ -40,7 +44,8 @@ class PackageConfig {
     if (monoPkgYaml.isEmpty) {
       // It's valid to have an empty `mono_pkg.yaml` file – it just results in
       // an empty config WRT travis.
-      return PackageConfig(relativePath, pubspec, [], [], [], [], false);
+      return PackageConfig(
+          relativePath, pubspec, [], [], [], [], [], false, false);
     }
     final rawConfig = RawConfig.fromJson(monoPkgYaml);
 
@@ -48,6 +53,7 @@ class PackageConfig {
     final jobs = <TravisJob>[];
 
     var sdkConfigUsed = false;
+    var osConfigUsed = false;
 
     final stageNames = rawConfig.stages.map((stage) {
       final stageYaml = stage.items;
@@ -91,7 +97,7 @@ class PackageConfig {
             jobOses = [jobValue as String];
           }
         } else {
-          sdkConfigUsed = true;
+          osConfigUsed = true;
         }
 
         for (var sdk in jobSdks) {
@@ -103,8 +109,16 @@ class PackageConfig {
       return stage.name;
     }).toList();
 
-    return PackageConfig(relativePath, pubspec, rawConfig.sdks, stageNames,
-        jobs, rawConfig.cache?.directories ?? const [], sdkConfigUsed);
+    return PackageConfig(
+        relativePath,
+        pubspec,
+        rawConfig.oses,
+        rawConfig.sdks,
+        stageNames,
+        jobs,
+        rawConfig.cache?.directories ?? const [],
+        sdkConfigUsed,
+        osConfigUsed);
   }
 
   bool get hasFlutterDependency {

--- a/mono_repo/lib/src/package_config.g.dart
+++ b/mono_repo/lib/src/package_config.g.dart
@@ -9,6 +9,7 @@ part of 'package_config.dart';
 TravisJob _$TravisJobFromJson(Map json) {
   return $checkedNew('TravisJob', json, () {
     final val = TravisJob(
+      $checkedConvert(json, 'os', (v) => v as String),
       $checkedConvert(json, 'package', (v) => v as String),
       $checkedConvert(json, 'sdk', (v) => v as String),
       $checkedConvert(json, 'stageName', (v) => v as String),
@@ -38,6 +39,7 @@ Map<String, dynamic> _$TravisJobToJson(TravisJob instance) {
   }
 
   writeNotNull('description', instance.description);
+  val['os'] = instance.os;
   val['package'] = instance.package;
   val['sdk'] = instance.sdk;
   val['stageName'] = instance.stageName;

--- a/mono_repo/lib/src/raw_config.dart
+++ b/mono_repo/lib/src/raw_config.dart
@@ -8,6 +8,9 @@ part 'raw_config.g.dart';
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class RawConfig {
+  @JsonKey(name: 'os', defaultValue: ['linux'])
+  final List<String> oses;
+
   @JsonKey(name: 'dart')
   final List<String> sdks;
 
@@ -15,7 +18,7 @@ class RawConfig {
 
   final RawCache cache;
 
-  RawConfig(this.sdks, List<RawStage> stages, this.cache)
+  RawConfig(this.oses, this.sdks, List<RawStage> stages, this.cache)
       : stages = stages ??
             [
               RawStage('unit_test', ['test'])

--- a/mono_repo/lib/src/raw_config.g.dart
+++ b/mono_repo/lib/src/raw_config.g.dart
@@ -8,8 +8,11 @@ part of 'raw_config.dart';
 
 RawConfig _$RawConfigFromJson(Map json) {
   return $checkedNew('RawConfig', json, () {
-    $checkKeys(json, allowedKeys: const ['dart', 'stages', 'cache']);
+    $checkKeys(json, allowedKeys: const ['os', 'dart', 'stages', 'cache']);
     final val = RawConfig(
+      $checkedConvert(json, 'os',
+              (v) => (v as List)?.map((e) => e as String)?.toList()) ??
+          ['linux'],
       $checkedConvert(
           json, 'dart', (v) => (v as List)?.map((e) => e as String)?.toList()),
       $checkedConvert(
@@ -22,7 +25,7 @@ RawConfig _$RawConfigFromJson(Map json) {
           json, 'cache', (v) => v == null ? null : RawCache.fromJson(v as Map)),
     );
     return val;
-  }, fieldKeyMap: const {'sdks': 'dart'});
+  }, fieldKeyMap: const {'oses': 'os', 'sdks': 'dart'});
 }
 
 RawCache _$RawCacheFromJson(Map json) {

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.2.0';
+const packageVersion = '2.3.0';

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/dart-lang/mono_repo
 author: Dart Team <misc@dartlang.org>
 

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -316,7 +316,7 @@ line 7, column 9: Unsupported value for "a". Stages are required to have at leas
       _expectParseThrows(
         monoYaml,
         r'''
-line 2, column 2: Unrecognized keys: [extra, more]; supported keys: [dart, stages, cache]
+line 2, column 2: Unrecognized keys: [extra, more]; supported keys: [os, dart, stages, cache]
   ╷
 2 │  "extra": "foo",
   │  ^^^^^^^
@@ -355,6 +355,8 @@ dart:
   - dev
   - stable
   - 1.23.0
+os:
+  - linux
 
 stages:
   - analyze_and_format:
@@ -364,9 +366,14 @@ stages:
         - dartfmt
       dart:
         - dev
+      os:
+        - windows
+        - linux
     - dartanalyzer: --fatal-infos --fatal-warnings .
       dart:
         - 1.23.0
+      os:
+        - osx
   - unit_test:
     - test: --platform chrome
     - test: --preset travis --total-shards 5 --shard-index 0
@@ -377,6 +384,7 @@ stages:
 List get _testConfig1expectedOutput => [
       {
         "description": "dartanalyzer && dartfmt",
+        "os": "windows",
         "package": "a",
         "sdk": "dev",
         "stageName": "analyze_and_format",
@@ -386,6 +394,18 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "description": "dartanalyzer && dartfmt",
+        "os": "linux",
+        "package": "a",
+        "sdk": "dev",
+        "stageName": "analyze_and_format",
+        "tasks": [
+          {"name": "dartanalyzer", "args": "--fatal-infos --fatal-warnings ."},
+          {"name": "dartfmt"}
+        ]
+      },
+      {
+        "os": "osx",
         "package": "a",
         "sdk": "1.23.0",
         "stageName": "analyze_and_format",
@@ -394,6 +414,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "dev",
         "stageName": "unit_test",
@@ -402,6 +423,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "stable",
         "stageName": "unit_test",
@@ -410,6 +432,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "1.23.0",
         "stageName": "unit_test",
@@ -418,6 +441,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "dev",
         "stageName": "unit_test",
@@ -429,6 +453,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "stable",
         "stageName": "unit_test",
@@ -440,6 +465,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "1.23.0",
         "stageName": "unit_test",
@@ -451,6 +477,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "dev",
         "stageName": "unit_test",
@@ -462,6 +489,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "stable",
         "stageName": "unit_test",
@@ -473,6 +501,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "1.23.0",
         "stageName": "unit_test",
@@ -484,6 +513,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "dev",
         "stageName": "unit_test",
@@ -492,6 +522,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "stable",
         "stageName": "unit_test",
@@ -500,6 +531,7 @@ List get _testConfig1expectedOutput => [
         ]
       },
       {
+        "os": "linux",
         "package": "a",
         "sdk": "1.23.0",
         "stageName": "unit_test",

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -62,16 +62,19 @@ jobs:
     - stage: analyze
       name: "SDK: dev; PKG: sub_pkg; TASKS: `dartanalyzer .`"
       dart: dev
+      os: linux
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh dartanalyzer
     - stage: analyze
       name: "SDK: dev; PKG: sub_pkg; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: dev
+      os: linux
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh dartfmt
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
       dart: dev
+      os: linux
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test
 
@@ -89,10 +92,13 @@ cache:
     - "$HOME/.pub-cache"
 ''';
 
-final _travisSh = r'''
+final _travisSh = '''
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
+$windowsBoilerplate
+'''
+    r'''
 if [[ -z ${PKGS} ]]; then
   echo -e '\033[31mPKGS environment variable must be set!\033[0m'
   exit 1

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -80,3 +80,28 @@ stages:
     - test: --preset travis --total-shards 9 --shard-index 8
     - test
 ''';
+
+final windowsBoilerplate = r'''
+# Support built in commands on windows out of the box.
+function pub {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command pub.bat "$@"
+    else
+        command pub "$@"
+    fi
+}
+function dartfmt {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartfmt.bat "$@"
+    else
+        command dartfmt "$@"
+    fi
+}
+function dartanalyzer {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartanalyzer.bat "$@"
+    else
+        command dartanalyzer "$@"
+    fi
+}
+''';

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -48,6 +48,10 @@ dart:
  - stable
  - 1.23.0
 
+os:
+  - linux
+  - windows
+
 stages:
   - analyze:
     - group:
@@ -55,9 +59,13 @@ stages:
         - dartfmt
       dart:
         - dev
+      os:
+        - osx
     - dartanalyzer:
       dart:
         - 1.23.0
+      os:
+        - windows
   - unit_test:
     - description: "chrome tests"
       test: --platform chrome

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:mono_repo/src/package_config.dart';
 import 'package:mono_repo/src/yaml.dart';
@@ -151,7 +152,6 @@ name: pkg_name
           'package:sub_pkg',
           'Make sure to mark `./tool/travis.sh` as executable.'
         ])));
-
     await d.file(travisFileName, _config2Yaml).validate();
     await d.file(travisShPath, _config2Shell).validate();
   });
@@ -258,16 +258,19 @@ jobs:
     - stage: format
       name: "SDK: dev; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: dev
+      os: linux
       env: PKGS="pkg_a"
       script: ./tool/travis.sh dartfmt
     - stage: format
       name: "SDK: stable; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: stable
+      os: linux
       env: PKGS="pkg_a"
       script: ./tool/travis.sh dartfmt
     - stage: format
       name: "SDK: dev; PKG: pkg_b; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: dev
+      os: linux
       env: PKGS="pkg_b"
       script: ./tool/travis.sh dartfmt
 
@@ -396,16 +399,19 @@ jobs:
     - stage: format
       name: "SDK: dev; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: dev
+      os: linux
       env: PKGS="pkg_a"
       script: ./tool/travis.sh dartfmt_0
     - stage: format
       name: "SDK: stable; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: stable
+      os: linux
       env: PKGS="pkg_a"
       script: ./tool/travis.sh dartfmt_0
     - stage: format
       name: "SDK: dev; PKG: pkg_b; TASKS: `dartfmt --dry-run --fix --set-exit-if-changed .`"
       dart: dev
+      os: linux
       env: PKGS="pkg_b"
       script: ./tool/travis.sh dartfmt_1
 
@@ -500,10 +506,13 @@ name: pkg_a
         ));
   });
 
-  test('top-level `dart` key value is no-op with group overrides', () async {
+  test('top-level `dart` and `os` key values are a no-op with group overrides',
+      () async {
     await d.dir('pkg_a', [
       d.file(monoPkgFileName, r'''
 dart:
+- unneeded
+os:
 - unneeded
 
 stages:
@@ -512,10 +521,12 @@ stages:
     - dartfmt
     - dartanalyzer: --fatal-warnings --fatal-infos .
     dart: [dev]
+    os: [windows]
   - group:
     - dartfmt
     - dartanalyzer: --fatal-warnings .
     dart: [2.1.1]
+    os: [osx]
 '''),
       d.file('pubspec.yaml', '''
 name: pkg_a
@@ -539,11 +550,13 @@ jobs:
     - stage: analyzer_and_format
       name: "SDK: dev; PKG: pkg_a; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-warnings --fatal-infos .`]"
       dart: dev
+      os: windows
       env: PKGS="pkg_a"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyzer_and_format
       name: "SDK: 2.1.1; PKG: pkg_a; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-warnings .`]"
       dart: "2.1.1"
+      os: osx
       env: PKGS="pkg_a"
       script: ./tool/travis.sh dartfmt dartanalyzer_1
 
@@ -1008,176 +1021,409 @@ jobs:
     - stage: analyze
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `dartanalyzer .`"
       dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh dartanalyzer
     - stage: analyze
       name: "SDK: dev; PKG: sub_pkg; TASKS: [`dartanalyzer .`, `dartfmt -n --set-exit-if-changed .`]"
       dart: dev
+      os: osx
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh dartanalyzer dartfmt
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: chrome tests"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_00
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: chrome tests"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_00
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: chrome tests"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_00
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: chrome tests"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_00
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: chrome tests"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_00
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: chrome tests"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_00
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 0`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_01
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 0`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_01
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 0`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_01
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 0`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_01
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 0`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_01
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 0`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_01
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 1`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_02
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 1`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_02
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 1`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_02
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 1`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_02
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 1`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_02
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 1`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_02
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 2`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_03
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 2`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_03
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 2`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_03
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 2`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_03
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 2`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_03
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 2`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_03
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 3`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_04
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 3`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 3`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_04
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 3`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_04
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 3`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_04
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 3`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_04
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 4`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 4`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 4`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 4`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_05
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 4`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 4`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_05
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 5`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_06
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 5`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 5`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_06
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 5`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_06
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 5`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_06
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 5`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_06
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 6`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_07
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 6`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_07
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 6`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_07
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 6`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_07
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 6`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_07
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 6`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_07
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 7`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_08
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 7`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_08
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 7`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_08
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 7`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_08
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 7`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_08
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 7`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_08
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 8`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_09
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 8`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_09
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 8`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_09
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 8`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_09
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 8`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_09
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis --total-shards 9 --shard-index 8`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_09
     - stage: unit_test
       name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test`"
       dart: "1.23.0"
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_10
+    - stage: unit_test
+      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test`"
+      dart: "1.23.0"
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_10
     - stage: unit_test
       name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
       dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_10
+    - stage: unit_test
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+      dart: dev
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_10
     - stage: unit_test
       name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test`"
       dart: stable
+      os: linux
+      env: PKGS="sub_pkg"
+      script: ./tool/travis.sh test_10
+    - stage: unit_test
+      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test`"
+      dart: stable
+      os: windows
       env: PKGS="sub_pkg"
       script: ./tool/travis.sh test_10
 

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -296,7 +296,7 @@ cache:
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-$_windowsBoilerplate
+$windowsBoilerplate
 '''
             r'''
 if [[ -z ${PKGS} ]]; then
@@ -444,7 +444,7 @@ cache:
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-$_windowsBoilerplate
+$windowsBoilerplate
 '''
             r'''
 if [[ -z ${PKGS} ]]; then
@@ -592,7 +592,7 @@ cache:
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-$_windowsBoilerplate
+$windowsBoilerplate
 '''
             r'''
 if [[ -z ${PKGS} ]]; then
@@ -937,7 +937,7 @@ final _config2Shell = '''
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
-$_windowsBoilerplate
+$windowsBoilerplate
 '''
     r"""
 if [[ -z ${PKGS} ]]; then
@@ -1462,29 +1462,4 @@ branches:
 cache:
   directories:
     - "$HOME/.pub-cache"
-''';
-
-final _windowsBoilerplate = r'''
-# Support built in commands on windows out of the box.
-function pub {
-       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
-        command pub.bat "$@"
-    else
-        command pub "$@"
-    fi
-}
-function dartfmt {
-       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
-        command dartfmt.bat "$@"
-    else
-        command dartfmt "$@"
-    fi
-}
-function dartanalyzer {
-       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
-        command dartanalyzer.bat "$@"
-    else
-        command dartanalyzer "$@"
-    fi
-}
 ''';

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:mono_repo/src/package_config.dart';
 import 'package:mono_repo/src/yaml.dart';

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -289,10 +289,16 @@ cache:
     - pkg_b/.dart_tool
 ''').validate();
 
-    await d.file(travisShPath, r'''
+    await d
+        .file(
+            travisShPath,
+            '''
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
+$_windowsBoilerplate
+'''
+            r'''
 if [[ -z ${PKGS} ]]; then
   echo -e '\033[31mPKGS environment variable must be set!\033[0m'
   exit 1
@@ -338,7 +344,8 @@ for PKG in ${PKGS}; do
 done
 
 exit ${EXIT_CODE}
-''').validate();
+''')
+        .validate();
   });
 
   test('two flavors of dartfmt with different arguments', () async {
@@ -430,10 +437,16 @@ cache:
     - pkg_b/.dart_tool
 ''').validate();
 
-    await d.file(travisShPath, r'''
+    await d
+        .file(
+            travisShPath,
+            '''
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
+$_windowsBoilerplate
+'''
+            r'''
 if [[ -z ${PKGS} ]]; then
   echo -e '\033[31mPKGS environment variable must be set!\033[0m'
   exit 1
@@ -483,7 +496,8 @@ for PKG in ${PKGS}; do
 done
 
 exit ${EXIT_CODE}
-''').validate();
+''')
+        .validate();
   });
 
   test('missing `dart` key', () async {
@@ -571,10 +585,16 @@ cache:
   directories:
     - "$HOME/.pub-cache"
 ''').validate();
-    await d.file(travisShPath, r'''
+    await d
+        .file(
+            travisShPath,
+            '''
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
+$_windowsBoilerplate
+'''
+            r'''
 if [[ -z ${PKGS} ]]; then
   echo -e '\033[31mPKGS environment variable must be set!\033[0m'
   exit 1
@@ -628,7 +648,8 @@ for PKG in ${PKGS}; do
 done
 
 exit ${EXIT_CODE}
-''').validate();
+''')
+        .validate();
   });
 
   group('mono_repo.yaml', () {
@@ -912,10 +933,13 @@ jobs:
   });
 }
 
-final _config2Shell = r"""
+final _config2Shell = '''
 #!/bin/bash
 # Created with package:mono_repo v1.2.3
 
+$_windowsBoilerplate
+'''
+    r"""
 if [[ -z ${PKGS} ]]; then
   echo -e '\033[31mPKGS environment variable must be set!\033[0m'
   exit 1
@@ -1438,4 +1462,29 @@ branches:
 cache:
   directories:
     - "$HOME/.pub-cache"
+''';
+
+final _windowsBoilerplate = r'''
+# Support built in commands on windows out of the box.
+function pub {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command pub.bat "$@"
+    else
+        command pub "$@"
+    fi
+}
+function dartfmt {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartfmt.bat "$@"
+    else
+        command dartfmt "$@"
+    fi
+}
+function dartanalyzer {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartanalyzer.bat "$@"
+    else
+        command dartanalyzer "$@"
+    fi
+}
 ''';


### PR DESCRIPTION
Fixes https://github.com/dart-lang/mono_repo/issues/170.

~This does not solve the problem of mapping `pub` => `pub.bat` etc, but it does allow for configuring the OS per package/task and expanding the stages based on that. This is enough that it is worth releasing for now I think, and we can follow up with the cleanup there.~

I went ahead and added the windows boilerplate as well.

cc @kevmoo in case you want to look as well