### PR TITLE
Add windows test bots, fix tests to pass on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,21 @@ jobs:
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: build
+      name: "SDK: 2.3.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
+      dart: "2.3.0"
+      os: windows
+      env: PKGS="mono_repo"
+      script: ./tool/travis.sh command_0
+    - stage: build
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: dev
       os: linux
+      env: PKGS="mono_repo"
+      script: ./tool/travis.sh command_0
+    - stage: build
+      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
+      dart: dev
+      os: windows
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: unit_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v2.2.0
+# Created with package:mono_repo v2.3.0
 language: dart
 
 jobs:
@@ -6,41 +6,73 @@ jobs:
     - stage: smoke_test
       name: "SDK: 2.3.0; PKGS: mono_repo, test_pkg; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.3.0"
+      os: linux
       env: PKGS="mono_repo test_pkg"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: smoke_test
       name: "SDK: dev; PKGS: mono_repo, test_pkg; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
+      os: linux
       env: PKGS="mono_repo test_pkg"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: build
       name: "SDK: 2.3.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: "2.3.0"
+      os: linux
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: build
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: dev
+      os: linux
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: unit_test
       name: "SDK: 2.3.0; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
       dart: "2.3.0"
+      os: linux
+      env: PKGS="mono_repo"
+      script: ./tool/travis.sh command_1 command_2
+    - stage: unit_test
+      name: "SDK: 2.3.0; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
+      dart: "2.3.0"
+      os: windows
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_1 command_2
     - stage: unit_test
       name: "SDK: dev; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
       dart: dev
+      os: linux
+      env: PKGS="mono_repo"
+      script: ./tool/travis.sh command_1 command_2
+    - stage: unit_test
+      name: "SDK: dev; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
+      dart: dev
+      os: windows
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_1 command_2
     - stage: unit_test
       name: "SDK: 2.3.0; PKG: test_pkg; TASKS: `pub run test`"
       dart: "2.3.0"
+      os: linux
+      env: PKGS="test_pkg"
+      script: ./tool/travis.sh test
+    - stage: unit_test
+      name: "SDK: 2.3.0; PKG: test_pkg; TASKS: `pub run test`"
+      dart: "2.3.0"
+      os: windows
       env: PKGS="test_pkg"
       script: ./tool/travis.sh test
     - stage: unit_test
       name: "SDK: dev; PKG: test_pkg; TASKS: `pub run test`"
       dart: dev
+      os: linux
+      env: PKGS="test_pkg"
+      script: ./tool/travis.sh test
+    - stage: unit_test
+      name: "SDK: dev; PKG: test_pkg; TASKS: `pub run test`"
+      dart: dev
+      os: windows
       env: PKGS="test_pkg"
       script: ./tool/travis.sh test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,29 +40,29 @@ jobs:
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: unit_test
-      name: "SDK: 2.3.0; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
+      name: "SDK: 2.3.0; PKG: mono_repo; TASKS: `pub run build_runner test -- -P presubmit`"
       dart: "2.3.0"
       os: linux
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1 command_2
+      script: ./tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: 2.3.0; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
+      name: "SDK: 2.3.0; PKG: mono_repo; TASKS: `pub run build_runner test -- -P presubmit`"
       dart: "2.3.0"
       os: windows
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1 command_2
+      script: ./tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: dev; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
+      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner test -- -P presubmit`"
       dart: dev
       os: linux
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1 command_2
+      script: ./tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: dev; PKG: mono_repo; TASKS: [`pub run build_runner test -- -x presubmit-only`, `pub run build_runner test -- --run-skipped -t presubmit-only`]"
+      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner test -- -P presubmit`"
       dart: dev
       os: windows
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1 command_2
+      script: ./tool/travis.sh command_1
     - stage: unit_test
       name: "SDK: 2.3.0; PKG: test_pkg; TASKS: `pub run test`"
       dart: "2.3.0"

--- a/mono_repo/dart_test.yaml
+++ b/mono_repo/dart_test.yaml
@@ -1,3 +1,4 @@
 tags:
   presubmit-only:
     skip: "Should only be run during presubmit"
+    presets: {presubmit: {skip: false}}

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -18,6 +18,9 @@ stages:
   - group:
     - command: pub run build_runner test -- -x presubmit-only
     - command: pub run build_runner test -- --run-skipped -t presubmit-only
+    os:
+      - linux
+      - windows
 
 cache:
   directories:

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -18,9 +18,7 @@ stages:
       - linux
       - windows
 - unit_test:
-  - group:
-    - command: pub run build_runner test -- -x presubmit-only
-    - command: pub run build_runner test -- --run-skipped -t presubmit-only
+  - command: pub run build_runner test -- -P presubmit
     os:
       - linux
       - windows

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -14,6 +14,9 @@ stages:
     dart: [2.3.0]
 - build:
   - command: pub run build_runner build test --delete-conflicting-outputs
+    os:
+      - linux
+      - windows
 - unit_test:
   - group:
     - command: pub run build_runner test -- -x presubmit-only

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -29,6 +29,7 @@ dev_dependencies:
   build_version: ^2.0.0
   build_vm_compilers: '>=0.1.0 <2.0.0'
   json_serializable: ^3.2.0
+  term_glyph: ^1.0.0
   test: ^1.3.0
   test_descriptor: ^1.0.0
   test_process: ^1.0.1

--- a/mono_repo/test/check_comand_test.dart
+++ b/mono_repo/test/check_comand_test.dart
@@ -75,7 +75,7 @@ void main() {
           flutterReport.pubspec.dependencies['flutter'] as SdkDependency;
       expect(sdkDep.sdk, 'flutter');
 
-      var recursiveReport = reports['baz/recursive'];
+      var recursiveReport = reports[p.join('baz', 'recursive')];
       expect(recursiveReport.packageName, 'baz.recursive');
       expect(recursiveReport.published, isTrue);
       expect(recursiveReport.pubspec.dependencies, hasLength(1));

--- a/mono_repo/test/check_comand_test.dart
+++ b/mono_repo/test/check_comand_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:mono_repo/src/commands/check.dart';
 import 'package:mono_repo/src/root_config.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
@@ -27,7 +28,8 @@ void main() {
     test('check', () {
       var reports = getPackageReports(RootConfig(rootDirectory: d.sandbox));
 
-      expect(reports.keys, ['bar', 'baz', 'baz/recursive', 'flutter', 'foo']);
+      expect(reports.keys,
+          ['bar', 'baz', p.join('baz', 'recursive'), 'flutter', 'foo']);
 
       var fooReport = reports['foo'];
       expect(fooReport.packageName, 'foo');

--- a/mono_repo/test/ensure_build_test.dart
+++ b/mono_repo/test/ensure_build_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Tags(['presubmit-only'])
+@OnPlatform({'windows': Skip('newlines are different')})
 
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -11,6 +11,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:mono_repo/src/package_config.dart';
 import 'package:mono_repo/src/yaml.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:test/test.dart';
 
 final _dummyPubspec = Pubspec('_example');
@@ -32,6 +33,8 @@ void _expectParseThrows(Object content, String expectedError) => expect(
     () => _parse(content), throwsCheckedFromJsonException(expectedError));
 
 void main() {
+  glyph.ascii = false;
+
   test('no stages - end up with one `unit_test` stage with one `test` task',
       () {
     var config = _parse({

--- a/mono_repo/test/mono_repo_test.dart
+++ b/mono_repo/test/mono_repo_test.dart
@@ -22,7 +22,7 @@ void main() {
   test('readme contains latest task output', () {
     var readme = File('README.md');
 
-    expect(readme.readAsStringSync().replaceAll(r'\r', ''),
+    expect(readme.readAsStringSync().replaceAll('\r', ''),
         contains('```\n$_helpOutput\n```'));
   });
 }

--- a/mono_repo/test/mono_repo_test.dart
+++ b/mono_repo/test/mono_repo_test.dart
@@ -7,9 +7,11 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
+final pubBinary = Platform.isWindows ? 'pub.bat' : 'pub';
+
 void main() {
   test('pub get gets dependencies', () async {
-    var process = await TestProcess.start('pub', ['run', 'mono_repo']);
+    var process = await TestProcess.start(pubBinary, ['run', 'mono_repo']);
 
     var output = await process.stdoutStream().join('\n');
     expect(output, _helpOutput);
@@ -20,7 +22,8 @@ void main() {
   test('readme contains latest task output', () {
     var readme = File('README.md');
 
-    expect(readme.readAsStringSync(), contains('```\n$_helpOutput\n```'));
+    expect(readme.readAsStringSync().replaceAll(r'\r', ''),
+        contains('```\n$_helpOutput\n```'));
   });
 }
 

--- a/mono_repo/test/presubmit_command_test.dart
+++ b/mono_repo/test/presubmit_command_test.dart
@@ -16,6 +16,8 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'shared.dart';
 
+final pubBinary = Platform.isWindows ? 'pub.bat' : 'pub';
+
 void main() {
   group('error reporting', () {
     test('no $travisShPath', () async {
@@ -75,9 +77,9 @@ void main() {
 
       await Process.run('chmod', ['+x', p.join('tool', 'travis.sh')],
           workingDirectory: repoPath);
-      await Process.run('pub', ['get'], workingDirectory: pkgAPath);
-      await Process.run(
-          'pub', ['global', 'activate', '-s', 'path', Directory.current.path]);
+      await Process.run(pubBinary, ['get'], workingDirectory: pkgAPath);
+      await Process.run(pubBinary,
+          ['global', 'activate', '-s', 'path', Directory.current.path]);
     });
 
     tearDownAll(() {
@@ -86,7 +88,7 @@ void main() {
 
     test('runs all tasks and packages', () async {
       var result = await Process.run(
-          'pub', ['global', 'run', 'mono_repo', 'presubmit', '--sdk=dev'],
+          pubBinary, ['global', 'run', 'mono_repo', 'presubmit', '--sdk=dev'],
           workingDirectory: repoPath);
       expect(result.exitCode, 0,
           reason: 'stderr:\n${result.stderr}\nstdout:\n${result.stdout}');
@@ -114,7 +116,7 @@ pkg_b
 
     test('can filter by package', () async {
       var result = await Process.run(
-          'pub',
+          pubBinary,
           [
             'global',
             'run',
@@ -138,7 +140,7 @@ pkg_b
 
     test('can filter by task', () async {
       var result = await Process.run(
-          'pub',
+          pubBinary,
           [
             'global',
             'run',
@@ -178,7 +180,7 @@ pkg_b
 
       test('cause an error and are reported', () async {
         var result = await Process.run(
-            'pub',
+            pubBinary,
             [
               'global',
               'run',

--- a/mono_repo/test/presubmit_command_test.dart
+++ b/mono_repo/test/presubmit_command_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Tags(['presubmit-only'])
+@OnPlatform({'windows': Skip('Cant run shell scripts on windows')})
 import 'dart:io';
 
 import 'package:io/ansi.dart';

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -16,7 +16,7 @@ import 'shared.dart';
 void main() {
   test('validate readme content', () {
     var readmeContent = File('README.md').readAsStringSync();
-    expect(readmeContent.replaceAll(r'\r', ''), contains(_pkgConfig));
+    expect(readmeContent.replaceAll('\r', ''), contains(_pkgConfig));
   });
 
   test('validate readme example output', () async {

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -16,7 +16,7 @@ import 'shared.dart';
 void main() {
   test('validate readme content', () {
     var readmeContent = File('README.md').readAsStringSync();
-    expect(readmeContent, contains(_pkgConfig));
+    expect(readmeContent.replaceAll(r'\r', ''), contains(_pkgConfig));
   });
 
   test('validate readme example output', () async {

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -6,12 +6,16 @@ import 'dart:async';
 
 import 'package:mono_repo/src/package_config.dart';
 import 'package:mono_repo/src/yaml.dart';
+import 'package:path/path.dart' as p;
+import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'shared.dart';
 
 void main() {
+  glyph.ascii = false;
+
   test('no package', () async {
     await d.dir('sub_pkg').create();
 
@@ -34,7 +38,8 @@ name: pkg_name
     expect(
         testGenerateTravisConfig,
         throwsUserExceptionWith(
-            'The contents of `sub_pkg/mono_pkg.yaml` must be a Map.', isNull));
+            'The contents of `${p.join('sub_pkg', 'mono_pkg.yaml')}` must be a Map.',
+            isNull));
   });
 
   test('empty $monoPkgFileName file', () async {

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -78,7 +78,7 @@ name: pkg_name
       testGenerateTravisConfig,
       throwsAParsedYamlException(
         startsWith(
-          'line 8, column 7 of sub_pkg/mono_pkg.yaml: '
+          'line 8, column 7 of ${p.join('sub_pkg', 'mono_pkg.yaml')}: '
           'Extra config options are not currently supported.',
         ),
       ),

--- a/test_pkg/mono_pkg.yaml
+++ b/test_pkg/mono_pkg.yaml
@@ -13,4 +13,7 @@ stages:
     - dartanalyzer: --fatal-warnings .
     dart: [2.3.0]
 - unit_test:
-  - test
+  - test:
+    os:
+      - linux
+      - windows

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
-# Created with package:mono_repo v2.2.0
+# Created with package:mono_repo v2.3.0
+
+# Support built in commands on windows out of the box.
+function pub {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command pub.bat "$@"
+    else
+        command pub "$@"
+    fi
+}
+function dartfmt {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartfmt.bat "$@"
+    else
+        command dartfmt "$@"
+    fi
+}
+function dartanalyzer {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartanalyzer.bat "$@"
+    else
+        command dartanalyzer "$@"
+    fi
+}
 
 if [[ -z ${PKGS} ]]; then
   echo -e '\033[31mPKGS environment variable must be set!\033[0m'

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -59,12 +59,8 @@ for PKG in ${PKGS}; do
       pub run build_runner build test --delete-conflicting-outputs || EXIT_CODE=$?
       ;;
     command_1)
-      echo 'pub run build_runner test -- -x presubmit-only'
-      pub run build_runner test -- -x presubmit-only || EXIT_CODE=$?
-      ;;
-    command_2)
-      echo 'pub run build_runner test -- --run-skipped -t presubmit-only'
-      pub run build_runner test -- --run-skipped -t presubmit-only || EXIT_CODE=$?
+      echo 'pub run build_runner test -- -P presubmit'
+      pub run build_runner test -- -P presubmit || EXIT_CODE=$?
       ;;
     dartanalyzer_0)
       echo 'dartanalyzer --fatal-infos --fatal-warnings .'


### PR DESCRIPTION
Fixes the tests so they can pass on windows - did not identify any actual windows problems other than that the `presubmit` command doesn't work because it tries to run the `travis.sh` script.