### PR TITLE
Fix presubmit test with latest pkg:test fixes

### DIFF
--- a/mono_repo/test/presubmit_command_test.dart
+++ b/mono_repo/test/presubmit_command_test.dart
@@ -54,7 +54,7 @@ void main() {
       File(p.join(pkgAPath, 'pubspec.yaml'))
         ..createSync(recursive: true)
         ..writeAsStringSync(pkgAPubspec);
-      File(p.join(pkgAPath, 'test', 'test.dart'))
+      File(p.join(pkgAPath, 'test', 'some_test.dart'))
         ..createSync(recursive: true)
         ..writeAsStringSync(basicTest);
 


### PR DESCRIPTION
pkg:test now fails (exit 1) when no tests are run
The integration test used to create a file `test/test.dart` which
is not a valid test file.

It was never run, but test still succeeded – until pkg:test changed

Renamed the generated file to test/some_test.dart