### PR TITLE
Fix presubmit test with latest pkg:test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v2.3.0
+# Created with package:mono_repo v2.3.1-dev
 language: dart
 
 jobs:
@@ -22,21 +22,9 @@ jobs:
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: build
-      name: "SDK: 2.6.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
-      dart: "2.6.0"
-      os: windows
-      env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_0
-    - stage: build
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: dev
       os: linux
-      env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_0
-    - stage: build
-      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
-      dart: dev
-      os: windows
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: unit_test
@@ -46,21 +34,9 @@ jobs:
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: 2.6.0; PKG: mono_repo; TASKS: `pub run build_runner test -- -P presubmit`"
-      dart: "2.6.0"
-      os: windows
-      env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1
-    - stage: unit_test
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner test -- -P presubmit`"
       dart: dev
       os: linux
-      env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1
-    - stage: unit_test
-      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner test -- -P presubmit`"
-      dart: dev
-      os: windows
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_1
     - stage: unit_test
@@ -70,21 +46,9 @@ jobs:
       env: PKGS="test_pkg"
       script: ./tool/travis.sh test
     - stage: unit_test
-      name: "SDK: 2.6.0; PKG: test_pkg; TASKS: `pub run test`"
-      dart: "2.6.0"
-      os: windows
-      env: PKGS="test_pkg"
-      script: ./tool/travis.sh test
-    - stage: unit_test
       name: "SDK: dev; PKG: test_pkg; TASKS: `pub run test`"
       dart: dev
       os: linux
-      env: PKGS="test_pkg"
-      script: ./tool/travis.sh test
-    - stage: unit_test
-      name: "SDK: dev; PKG: test_pkg; TASKS: `pub run test`"
-      dart: dev
-      os: windows
       env: PKGS="test_pkg"
       script: ./tool/travis.sh test
 

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -16,12 +16,14 @@ stages:
   - command: pub run build_runner build test --delete-conflicting-outputs
     os:
       - linux
-      - windows
+      # TODO(kevmoo) Re-enable windows - dart-lang/mono_repo#183
+      #- windows
 - unit_test:
   - command: pub run build_runner test -- -P presubmit
     os:
       - linux
-      - windows
+      # TODO(kevmoo) Re-enable windows - dart-lang/mono_repo#183
+      #- windows
 
 cache:
   directories:

--- a/mono_repo/test/presubmit_command_test.dart
+++ b/mono_repo/test/presubmit_command_test.dart
@@ -54,7 +54,7 @@ void main() {
       File(p.join(pkgAPath, 'pubspec.yaml'))
         ..createSync(recursive: true)
         ..writeAsStringSync(pkgAPubspec);
-      File(p.join(pkgAPath, 'test', 'test.dart'))
+      File(p.join(pkgAPath, 'test', 'some_test.dart'))
         ..createSync(recursive: true)
         ..writeAsStringSync(basicTest);
 

--- a/test_pkg/mono_pkg.yaml
+++ b/test_pkg/mono_pkg.yaml
@@ -16,4 +16,5 @@ stages:
   - test:
     os:
       - linux
-      - windows
+      # TODO(kevmoo) Re-enable windows - dart-lang/mono_repo#183
+      #- windows

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v2.3.0
+# Created with package:mono_repo v2.3.1-dev
 
 # Support built in commands on windows out of the box.
 function pub {


### PR DESCRIPTION
pkg:test now fails (exit 1) when no tests are run
The integration test used to create a file `test/test.dart` which
is not a valid test file.

It was never run, but test still succeeded – until pkg:test changed

Renamed the generated file to test/some_test.dart